### PR TITLE
feat(mcp): 新增博客专属 MCP 服务器 + fix(markdown): 修复表格渲染

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -1,0 +1,16 @@
+import security from "eslint-plugin-security";
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+export default [
+  {
+    files: ["**/*.{ts,tsx}"],
+    plugins: { security, "@typescript-eslint": tseslint },
+    languageOptions: { parser: tsparser, parserOptions: { ecmaVersion: "latest", sourceType: "module" } },
+    rules: {
+      ...security.configs.recommended.rules,
+      "no-eval": "error",
+      "no-implied-eval": "error",
+    },
+  },
+  { ignores: ["dist/", "node_modules/", "*.config.*"] },
+];

--- a/client/src/components/post-reactions.tsx
+++ b/client/src/components/post-reactions.tsx
@@ -50,7 +50,10 @@ export function PostReactions({ slug }: PostReactionsProps) {
 
     setInFlight(prev => new Set(prev).add(type));
     setAnimating(type);
-    setTimeout(() => setAnimating(null), 600);
+    const clickedType = type;
+    setTimeout(() => {
+      setAnimating((prev) => (prev === clickedType ? null : prev));
+    }, 600);
 
     try {
       const requestSlug = slug;

--- a/client/src/components/reading-controls.tsx
+++ b/client/src/components/reading-controls.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Settings, X, Minus, Plus, Type, Moon, Sun, Monitor, Minimize, BookOpen } from "lucide-react";
+
+export type ReadingTheme = "light" | "sepia" | "dark" | "system";
+export type FontFamily = "sans" | "serif";
+
+export interface ReadingPreferences {
+  theme: ReadingTheme;
+  fontFamily: FontFamily;
+  fontSize: number; // base font size, default 17
+  lineHeight: number; // base line height, default 2.0
+  maxWidth: number; // max width of the container, default 780
+}
+
+const DEFAULT_PREFERENCES: ReadingPreferences = {
+  theme: "system",
+  fontFamily: "sans",
+  fontSize: 17,
+  lineHeight: 2.0,
+  maxWidth: 780,
+};
+
+const STORAGE_KEY = "monolith_reading_preferences";
+
+export function useReadingPreferences() {
+  const [preferences, setPreferences] = useState<ReadingPreferences>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        return { ...DEFAULT_PREFERENCES, ...JSON.parse(stored) };
+      }
+    } catch {
+      // ignore
+    }
+    return DEFAULT_PREFERENCES;
+  });
+
+  const updatePreference = useCallback(<K extends keyof ReadingPreferences>(key: K, value: ReadingPreferences[K]) => {
+    setPreferences((prev) => {
+      const next = { ...prev, [key]: value };
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  return { preferences, updatePreference };
+}
+
+export function ReadingControls({
+  isActive,
+  onClose,
+  preferences,
+  updatePreference,
+}: {
+  isActive: boolean;
+  onClose: () => void;
+  preferences: ReadingPreferences;
+  updatePreference: <K extends keyof ReadingPreferences>(key: K, value: ReadingPreferences[K]) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Click outside to close the config panel
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isOpen]);
+
+  if (!isActive) return null;
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={`fixed bottom-[24px] right-[24px] z-50 flex flex-col items-end gap-[12px] opacity-0 animate-fade-in-up md:bottom-[40px] md:right-[40px]`}
+      style={{ animationFillMode: "forwards" }}
+    >
+      {/* 选项面板 (Popover) */}
+      {isOpen && (
+        <div className="w-[280px] origin-bottom-right rounded-2xl border border-border/30 bg-card/80 p-[20px] shadow-2xl backdrop-blur-xl animate-scale-in">
+          <div className="mb-[16px] flex items-center justify-between">
+            <span className="text-[14px] font-medium tracking-wide">阅读偏好</span>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="rounded-full p-[4px] text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <X className="h-[14px] w-[14px]" />
+            </button>
+          </div>
+
+          <div className="space-y-[20px] text-[13px]">
+            {/* 主题选择 */}
+            <div className="space-y-[8px]">
+              <span className="text-[12px] text-muted-foreground/60">背景主题</span>
+              <div className="grid grid-cols-4 gap-[8px]">
+                <button
+                  onClick={() => updatePreference("theme", "light")}
+                  className={`flex h-[36px] items-center justify-center rounded-lg border bg-[#f8f9fa] text-[#333] transition-all hover:border-[#aaa] ${preferences.theme === "light" ? "border-cyan-500 shadow-[0_0_0_1px_theme(colors.cyan.500)]" : "border-transparent"}`}
+                  title="白昼"
+                ><Sun className="h-[14px] w-[14px]" /></button>
+                <button
+                  onClick={() => updatePreference("theme", "sepia")}
+                  className={`flex h-[36px] items-center justify-center rounded-lg border bg-[#f4ece3] text-[#5b4a3a] transition-all hover:border-[#d4c6b3] ${preferences.theme === "sepia" ? "border-amber-500 shadow-[0_0_0_1px_theme(colors.amber.500)]" : "border-transparent"}`}
+                  title="羊皮纸"
+                ><BookOpen className="h-[14px] w-[14px]" /></button>
+                <button
+                  onClick={() => updatePreference("theme", "dark")}
+                  className={`flex h-[36px] items-center justify-center rounded-lg border bg-[#1a1a1c] text-[#e0e0e0] transition-all hover:border-[#444] ${preferences.theme === "dark" ? "border-cyan-500 shadow-[0_0_0_1px_theme(colors.cyan.500)]" : "border-transparent"}`}
+                  title="深渊"
+                ><Moon className="h-[14px] w-[14px]" /></button>
+                <button
+                  onClick={() => updatePreference("theme", "system")}
+                  className={`flex h-[36px] items-center justify-center rounded-lg border bg-accent/20 text-foreground transition-all hover:bg-accent/40 ${preferences.theme === "system" ? "border-cyan-500 shadow-[0_0_0_1px_theme(colors.cyan.500)]" : "border-transparent"}`}
+                  title="跟随系统"
+                ><Monitor className="h-[14px] w-[14px]" /></button>
+              </div>
+            </div>
+
+            {/* 字体选择 */}
+            <div className="space-y-[8px]">
+              <span className="text-[12px] text-muted-foreground/60">字体样式</span>
+              <div className="grid grid-cols-2 gap-[8px]">
+                <button
+                  onClick={() => updatePreference("fontFamily", "sans")}
+                  className={`flex h-[36px] items-center justify-center rounded-lg border bg-accent/10 transition-all hover:bg-accent/30 ${preferences.fontFamily === "sans" ? "border-cyan-500 text-cyan-400" : "border-border/30 text-muted-foreground"}`}
+                >
+                  <span className="font-sans">无衬线体</span>
+                </button>
+                <button
+                  onClick={() => updatePreference("fontFamily", "serif")}
+                  className={`flex h-[36px] items-center justify-center rounded-lg border bg-accent/10 transition-all hover:bg-accent/30 ${preferences.fontFamily === "serif" ? "border-cyan-500 text-cyan-400" : "border-border/30 text-muted-foreground"}`}
+                >
+                  <span className="font-serif">衬线体</span>
+                </button>
+              </div>
+            </div>
+
+            {/* 字号行距调整 */}
+            <div className="space-y-[8px]">
+              <span className="text-[12px] text-muted-foreground/60">排版 (A: {preferences.fontSize} / H: {preferences.lineHeight.toFixed(1)})</span>
+              <div className="grid grid-cols-2 gap-[16px]">
+                {/* 字号 */}
+                <div className="flex h-[36px] items-center justify-between rounded-lg border border-border/30 bg-accent/10 px-[12px]">
+                  <button onClick={() => updatePreference("fontSize", Math.max(14, preferences.fontSize - 1))} className="text-muted-foreground hover:text-foreground">
+                    <Minus className="h-[12px] w-[12px]" />
+                  </button>
+                  <Type className="h-[14px] w-[14px] text-muted-foreground/50" />
+                  <button onClick={() => updatePreference("fontSize", Math.min(24, preferences.fontSize + 1))} className="text-muted-foreground hover:text-foreground">
+                    <Plus className="h-[12px] w-[12px]" />
+                  </button>
+                </div>
+                {/* 行距 */}
+                <div className="flex h-[36px] items-center justify-between rounded-lg border border-border/30 bg-accent/10 px-[12px]">
+                  <button onClick={() => updatePreference("lineHeight", Math.max(1.4, Number((preferences.lineHeight - 0.1).toFixed(1))))} className="text-muted-foreground hover:text-foreground">
+                    <Minus className="h-[12px] w-[12px]" />
+                  </button>
+                  <span className="text-[10px] uppercase font-mono tracking-widest text-muted-foreground/50">Hgt</span>
+                  <button onClick={() => updatePreference("lineHeight", Math.min(3.0, Number((preferences.lineHeight + 0.1).toFixed(1))))} className="text-muted-foreground hover:text-foreground">
+                    <Plus className="h-[12px] w-[12px]" />
+                  </button>
+                </div>
+              </div>
+            </div>
+            
+            {/* 专注宽度 */}
+            <div className="space-y-[8px]">
+              <span className="text-[12px] text-muted-foreground/60">阅读区宽度</span>
+              <div className="flex h-[36px] items-center justify-between rounded-lg border border-border/30 bg-accent/10 px-[12px]">
+                <button title="收窄" onClick={() => updatePreference("maxWidth", Math.max(500, preferences.maxWidth - 50))} className="text-muted-foreground hover:text-foreground">
+                  <Minus className="h-[12px] w-[12px]" />
+                </button>
+                <span className="text-[11px] font-mono text-muted-foreground/80">{preferences.maxWidth}px</span>
+                <button title="变宽" onClick={() => updatePreference("maxWidth", Math.min(1200, preferences.maxWidth + 50))} className="text-muted-foreground hover:text-foreground">
+                  <Plus className="h-[12px] w-[12px]" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 悬浮操作按钮组 */}
+      <div className="flex flex-col items-center gap-[12px] rounded-full border border-border/30 bg-card/60 p-[6px] shadow-lg backdrop-blur-xl transition-all hover:bg-card/80 hover:shadow-xl hover:border-border/50">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className={`flex h-[40px] w-[40px] items-center justify-center rounded-full transition-all ${isOpen ? "bg-cyan-500 text-white shadow-cyan-500/20" : "bg-transparent text-foreground hover:bg-accent/40"}`}
+          title="排版设置"
+        >
+          <Settings className={`h-[18px] w-[18px] ${isOpen ? "rotate-90 transition-transform duration-300" : ""}`} />
+        </button>
+        <div className="h-[1px] w-[20px] bg-border/40" />
+        <button
+          onClick={onClose}
+          className="group flex h-[40px] w-[40px] items-center justify-center rounded-full bg-transparent transition-all hover:bg-red-500/10"
+          title="退出阅读模式 (ESC)"
+        >
+          <Minimize className="h-[18px] w-[18px] text-muted-foreground transition-colors group-hover:text-red-400" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/share-buttons.tsx
+++ b/client/src/components/share-buttons.tsx
@@ -1,5 +1,5 @@
 import { Link2, Share2 } from "lucide-react";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 // 自定义 SVG Icons 因为 Lucide移除了品牌图标
 const TwitterIcon = ({ className }: { className?: string }) => (
@@ -22,14 +22,22 @@ interface ShareButtonsProps {
 
 export function ShareButtons({ title, url, className = "" }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<number | null>(null);
   const shareUrl = url || (typeof window !== "undefined" ? window.location.href : "");
 
   const handleCopy = () => {
     navigator.clipboard.writeText(shareUrl).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = window.setTimeout(() => setCopied(false), 2000);
     }).catch(console.error);
   };
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current);
+    };
+  }, []);
 
   const handleNativeShare = () => {
     if (navigator.share) {

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -1517,13 +1517,13 @@
 }
 
 /* 亮色模式阅读退出按钮 */
-:root:not(.dark) .reading-mode-exit-fab {
+[data-theme="light"] .reading-mode-exit-fab {
   border-color: oklch(0.8 0 0 / 0.3);
   background: oklch(0.98 0 0 / 0.9);
   color: oklch(0.4 0 0);
 }
 
-:root:not(.dark) .reading-mode-exit-fab:hover {
+[data-theme="light"] .reading-mode-exit-fab:hover {
   background: oklch(0.95 0 0 / 0.95);
   color: oklch(0.15 0 0);
   border-color: oklch(0.6 0 0 / 0.3);

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -403,7 +403,7 @@
   border: 1px solid oklch(1 0 0 / 8%);
   border-radius: 5px;
   color: oklch(0.85 0.06 220);
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 /* 代码块 */

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -292,15 +292,16 @@
    ───────────────────────────────────────────── */
 .prose-monolith {
   font-size: 15px;
-  line-height: 1.8;
-  letter-spacing: 0;
+  line-height: 1.9;
+  letter-spacing: 0.012em;
   color: oklch(0.85 0 0);
+  word-spacing: 0.02em;
 }
 
 /* 标题 */
 .prose-monolith h2 {
-  margin-top: 40px;
-  margin-bottom: 16px;
+  margin-top: 48px;
+  margin-bottom: 18px;
   font-size: 22px;
   font-weight: 600;
   letter-spacing: -0.01em;
@@ -309,8 +310,8 @@
 }
 
 .prose-monolith h3 {
-  margin-top: 32px;
-  margin-bottom: 12px;
+  margin-top: 36px;
+  margin-bottom: 14px;
   font-size: 18px;
   font-weight: 600;
   letter-spacing: 0;
@@ -329,7 +330,7 @@
 
 /* 段落 */
 .prose-monolith p {
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 /* 链接 */
@@ -355,8 +356,8 @@
 /* 列表 */
 .prose-monolith ul,
 .prose-monolith ol {
-  margin-bottom: 16px;
-  padding-left: 20px;
+  margin-bottom: 20px;
+  padding-left: 22px;
 }
 
 .prose-monolith ul {
@@ -368,8 +369,9 @@
 }
 
 .prose-monolith li {
-  margin-bottom: 6px;
+  margin-bottom: 8px;
   padding-left: 4px;
+  line-height: 1.8;
 }
 
 .prose-monolith li::marker {
@@ -378,8 +380,8 @@
 
 /* 引用块 */
 .prose-monolith blockquote {
-  margin: 24px 0;
-  padding: 16px 20px;
+  margin: 28px 0;
+  padding: 16px 24px;
   border-left: 3px solid oklch(0.5 0.1 220 / 50%);
   background: oklch(1 0 0 / 4%);
   border-radius: 0 8px 8px 0;
@@ -404,7 +406,7 @@
 
 /* 代码块 */
 .prose-monolith pre {
-  margin: 20px 0;
+  margin: 24px 0;
   padding: 16px 20px;
   border-radius: 8px;
   background: oklch(0.15 0.006 220) !important;
@@ -412,6 +414,7 @@
   overflow-x: auto;
   font-size: 13px;
   line-height: 1.85;
+  letter-spacing: 0;
   font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
 }
 
@@ -421,6 +424,45 @@
   border: none;
   font-size: inherit;
   color: oklch(0.85 0 0);
+}
+
+/* 代码块包裹容器间距（统一管理 margin，pre 自身 margin 被 has-header 覆盖为 0） */
+.prose-monolith .code-block-wrapper {
+  margin: 24px 0;
+}
+
+.prose-monolith .code-block-wrapper pre {
+  margin-top: 0;
+}
+
+/* ── 块间衔接优化 ── */
+/* 标题后紧接代码块/表格/引用，缩小间距避免割裂感 */
+.prose-monolith h2 + .code-block-wrapper,
+.prose-monolith h3 + .code-block-wrapper,
+.prose-monolith h4 + .code-block-wrapper {
+  margin-top: 16px;
+}
+
+.prose-monolith h2 + .table-wrapper,
+.prose-monolith h3 + .table-wrapper,
+.prose-monolith h4 + .table-wrapper {
+  margin-top: 16px;
+}
+
+.prose-monolith h2 + blockquote,
+.prose-monolith h3 + blockquote,
+.prose-monolith h4 + blockquote {
+  margin-top: 14px;
+}
+
+/* 连续代码块之间缩小间距 */
+.prose-monolith .code-block-wrapper + .code-block-wrapper {
+  margin-top: 16px;
+}
+
+/* 段落最后一个元素不要底部间距（避免与下一个块元素双重空白） */
+.prose-monolith p:last-child {
+  margin-bottom: 0;
 }
 
 /* 分隔线 */
@@ -433,7 +475,7 @@
 /* 表格响应式包裹 */
 .prose-monolith .table-wrapper {
   overflow-x: auto;
-  margin: 20px 0;
+  margin: 28px 0;
   border-radius: 8px;
   border: 1px solid oklch(1 0 0 / 6%);
 }

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -395,13 +395,15 @@
 
 /* 行内代码 */
 .prose-monolith code:not(pre code) {
-  padding: 2px 6px;
+  padding: 3px 8px;
+  margin: 0 3px;
   font-size: 13px;
   font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
   background: oklch(1 0 0 / 6%);
   border: 1px solid oklch(1 0 0 / 8%);
-  border-radius: 4px;
+  border-radius: 5px;
   color: oklch(0.85 0.06 220);
+  word-break: break-word;
 }
 
 /* 代码块 */

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -1548,80 +1548,87 @@
   transform: translateY(0);
 }
 
-  /* ── 阅读模式 ─────────────────────────────── */
+  /* ── 阅读模式与控制面板 ─────────────────────────────── */
   .reading-mode .app-header,
   .reading-mode .app-footer,
-.reading-mode .reading-progress-bar,
-.reading-mode .toc-desktop,
-.reading-mode .toc-mobile,
-.reading-mode .reading-mode-toggle {
-  display: none !important;
-}
-
-.reading-mode .post-layout {
-  max-width: 780px;
-  display: block;
-}
-
-.reading-mode .post-content {
-  max-width: 100%;
-  grid-column: auto;
-}
-
-.reading-mode .prose-monolith {
-  font-size: 17px;
-  line-height: 2;
-  letter-spacing: 0.01em;
-}
-
-/* 阅读模式浮动退出按钮 */
-.reading-mode-exit-fab {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 1px solid oklch(0.3 0 0 / 0.3);
-  background: oklch(0.15 0 0 / 0.85);
-  color: oklch(0.7 0 0);
-  cursor: pointer;
-  backdrop-filter: blur(12px);
-  transition: all 0.25s ease;
-  animation: reading-fab-in 0.3s ease-out;
-}
-
-.reading-mode-exit-fab:hover {
-  background: oklch(0.2 0 0 / 0.95);
-  color: oklch(0.95 0 0);
-  transform: scale(1.08);
-  border-color: oklch(0.5 0 0 / 0.3);
-}
-
-@keyframes reading-fab-in {
-  from {
-    opacity: 0;
-    transform: scale(0.6) rotate(-90deg);
+  .reading-mode .reading-progress-bar,
+  .reading-mode .toc-desktop,
+  .reading-mode .toc-mobile,
+  .reading-mode .reading-mode-toggle {
+    display: none !important;
   }
-  to {
-    opacity: 1;
-    transform: scale(1) rotate(0deg);
+
+  /* 动态宽度 */
+  .reading-mode .post-layout {
+    max-width: var(--rm-width, 780px) !important;
+    display: block;
+    transition: max-width 0.3s ease;
   }
-}
 
-/* 亮色模式阅读退出按钮 */
-[data-theme="light"] .reading-mode-exit-fab {
-  border-color: oklch(0.8 0 0 / 0.3);
-  background: oklch(0.98 0 0 / 0.9);
-  color: oklch(0.4 0 0);
-}
+  .reading-mode .post-content {
+    max-width: 100%;
+    grid-column: auto;
+  }
 
-[data-theme="light"] .reading-mode-exit-fab:hover {
-  background: oklch(0.95 0 0 / 0.95);
-  color: oklch(0.15 0 0);
-  border-color: oklch(0.6 0 0 / 0.3);
-}
+  /* 动态字号、行距、字体 */
+  .reading-mode .prose-monolith {
+    font-family: var(--rm-font, inherit);
+    font-size: var(--rm-size, 17px);
+    line-height: var(--rm-line-height, 2.0);
+    letter-spacing: 0.01em;
+    transition: font-size 0.2s ease, line-height 0.2s ease;
+  }
+  
+  .reading-mode .prose-monolith p, 
+  .reading-mode .prose-monolith li,
+  .reading-mode .prose-monolith blockquote {
+    color: inherit; /* 让文字颜色跟随外层被覆盖的颜色 */
+  }
+
+  /* --- 阅读主题覆写 --- */
+  
+  html[data-reading-theme="sepia"] body {
+    background-color: #f4ece3 !important;
+    color: #5b4a3a !important;
+  }
+  html[data-reading-theme="sepia"] .prose-monolith h1,
+  html[data-reading-theme="sepia"] .prose-monolith h2,
+  html[data-reading-theme="sepia"] .prose-monolith h3,
+  html[data-reading-theme="sepia"] .prose-monolith h4 {
+    color: #4a3c31 !important;
+  }
+  html[data-reading-theme="sepia"] .prose-monolith strong {
+    color: #3d3025 !important;
+  }
+  html[data-reading-theme="sepia"] .prose-monolith a {
+    color: #a46d3e !important;
+    box-shadow: 0 1px 0 0 rgba(164, 109, 62, 0.4) !important;
+  }
+
+  html[data-reading-theme="dark"] body {
+    background-color: #1a1a1c !important;
+    color: #e0e0e0 !important;
+  }
+  html[data-reading-theme="dark"] .prose-monolith h1,
+  html[data-reading-theme="dark"] .prose-monolith h2,
+  html[data-reading-theme="dark"] .prose-monolith h3,
+  html[data-reading-theme="dark"] .prose-monolith h4 {
+    color: #ffffff !important;
+  }
+  html[data-reading-theme="dark"] .prose-monolith strong {
+    color: #ffffff !important;
+  }
+  
+  html[data-reading-theme="light"] body {
+    background-color: #f8f9fa !important;
+    color: #333333 !important;
+  }
+  html[data-reading-theme="light"] .prose-monolith h1,
+  html[data-reading-theme="light"] .prose-monolith h2,
+  html[data-reading-theme="light"] .prose-monolith h3,
+  html[data-reading-theme="light"] .prose-monolith h4 {
+    color: #111111 !important;
+  }
+  html[data-reading-theme="light"] .prose-monolith strong {
+    color: #000000 !important;
+  }

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -405,13 +405,13 @@
 /* 代码块 */
 .prose-monolith pre {
   margin: 20px 0;
-  padding: 20px;
+  padding: 16px 20px;
   border-radius: 8px;
   background: oklch(0.15 0.006 220) !important;
   border: 1px solid oklch(1 0 0 / 6%);
   overflow-x: auto;
   font-size: 13px;
-  line-height: 1.7;
+  line-height: 1.85;
   font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
 }
 
@@ -468,26 +468,69 @@
   background: oklch(1 0 0 / 2%);
 }
 
-/* 代码块语言标签 */
-.prose-monolith pre {
-  position: relative;
+/* 代码块顶部信息栏（语言标签 + 复制按钮） */
+.prose-monolith .code-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px 6px 16px;
+  background: oklch(0.13 0.006 220);
+  border: 1px solid oklch(1 0 0 / 6%);
+  border-bottom: none;
+  border-radius: 8px 8px 0 0;
+}
+
+.prose-monolith .has-header > pre {
+  border-radius: 0 0 8px 8px;
+  margin-top: 0;
 }
 
 .prose-monolith .code-lang {
-  position: absolute;
-  top: 12px;
-  right: 42px;
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: oklch(0.45 0 0);
+  letter-spacing: 0.08em;
+  font-weight: 500;
+  color: oklch(0.5 0.02 220);
   pointer-events: none;
   user-select: none;
+  font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
 }
 
-/* 有标题时语言标签位置调整 */
-.prose-monolith .has-title .code-lang {
-  top: 50px;
+/* 复制按钮（信息栏内） */
+.prose-monolith .copy-code-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  gap: 5px;
+  border-radius: 6px;
+  border: 1px solid oklch(1 0 0 / 8%);
+  background: oklch(1 0 0 / 4%);
+  color: oklch(0.45 0 0);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  opacity: 0.6;
+}
+
+.prose-monolith .copy-code-btn:hover {
+  opacity: 1;
+  color: oklch(0.7 0 0);
+  background: oklch(1 0 0 / 8%);
+  border-color: oklch(1 0 0 / 15%);
+}
+
+.prose-monolith .copy-code-btn svg {
+  flex-shrink: 0;
+}
+
+/* 有标题栏时，复制按钮放标题栏右侧 */
+.prose-monolith .has-title .code-header {
+  display: none;
+}
+
+.prose-monolith .code-title-bar .copy-code-btn {
+  margin-left: auto;
 }
 
 /* 代码块标题栏 */
@@ -720,13 +763,23 @@
   color: oklch(0.35 0.08 250);
   border-color: oklch(0 0 0 / 8%);
 }
-:root[data-theme="light"] .prose-monolith .code-lang {
-  color: oklch(0.55 0 0);
-}
+
 :root[data-theme="light"] .prose-monolith .copy-code-btn {
   color: oklch(0.45 0 0);
   background: oklch(0.93 0 0);
   border-color: oklch(0 0 0 / 10%);
+}
+:root[data-theme="light"] .prose-monolith .copy-code-btn:hover {
+  color: oklch(0.25 0 0);
+  background: oklch(0.90 0 0);
+  border-color: oklch(0 0 0 / 15%);
+}
+:root[data-theme="light"] .prose-monolith .code-header {
+  background: oklch(0.93 0.002 250);
+  border-color: oklch(0 0 0 / 8%);
+}
+:root[data-theme="light"] .prose-monolith .code-lang {
+  color: oklch(0.45 0.02 250);
 }
 :root[data-theme="light"] .prose-monolith .code-title-bar {
   background: oklch(0.93 0.002 250);

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -198,11 +198,43 @@ renderer.image = ({ href, title, text }: { href: string; title?: string | null; 
   return `<figure class="md-figure"><img src="${href}" alt="${escapeHtml(text)}" loading="lazy" decoding="async" data-lazy-img${titleAttr} class="lazy-img"/>${text ? `<figcaption>${escapeHtml(text)}</figcaption>` : ""}</figure>`;
 };
 
-// 表格：响应式包裹
-renderer.table = (token: any) => {
-  const header = token.header || '';
-  const body = token.body || token.rows || '';
-  return `<div class="table-wrapper"><table><thead>${header}</thead><tbody>${body}</tbody></table></div>`;
+// 表格：响应式包裹（兼容 marked v15+ 的 token 结构）
+renderer.table = function (token: any) {
+  // marked v15+ 传入的是 token 对象，header 和 rows 是嵌套 Token 数组
+  // 需要手动构建 HTML 表格
+  let headerHtml = "";
+  let bodyHtml = "";
+
+  // 处理表头
+  if (token.header && Array.isArray(token.header)) {
+    headerHtml = "<tr>" + token.header.map((cell: any) => {
+      const align = cell.align ? ` style="text-align:${cell.align}"` : "";
+      const cellText = cell.tokens
+        ? this.parser.parseInline(cell.tokens)
+        : (typeof cell.text === "string" ? cell.text : String(cell));
+      return `<th${align}>${cellText}</th>`;
+    }).join("") + "</tr>";
+  } else if (typeof token.header === "string") {
+    headerHtml = token.header;
+  }
+
+  // 处理表体
+  if (token.rows && Array.isArray(token.rows)) {
+    bodyHtml = token.rows.map((row: any) => {
+      if (!Array.isArray(row)) return typeof row === "string" ? row : "";
+      return "<tr>" + row.map((cell: any) => {
+        const align = cell.align ? ` style="text-align:${cell.align}"` : "";
+        const cellText = cell.tokens
+          ? this.parser.parseInline(cell.tokens)
+          : (typeof cell.text === "string" ? cell.text : String(cell));
+        return `<td${align}>${cellText}</td>`;
+      }).join("") + "</tr>";
+    }).join("");
+  } else if (typeof token.body === "string") {
+    bodyHtml = token.body;
+  }
+
+  return `<div class="table-wrapper"><table><thead>${headerHtml}</thead><tbody>${bodyHtml}</tbody></table></div>`;
 };
 
 // 链接：外部链接自动 target="_blank"

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -60,9 +60,13 @@ function slugify(text: string): string {
     .replace(/^-|-$/g, "");        // 去除首尾连字符
 }
 
-renderer.heading = ({ text, depth }: { text: string; depth: number }) => {
-  const id = slugify(text);
-  return `<h${depth} id="${id}">${text}</h${depth}>`;
+renderer.heading = function ({ text, depth, tokens }: { text: string; depth: number; tokens?: any[] }) {
+  const id = slugify(text); // slugify 用原始纯文本生成锚点 id
+  // 用 parseInline 解析 inline 格式（粗体、代码等）为 HTML
+  const html = tokens && this.parser
+    ? this.parser.parseInline(tokens)
+    : text;
+  return `<h${depth} id="${id}">${html}</h${depth}>`;
 };
 
 // 代码块：高亮 + 语言标签 + 复制按钮 + 行号 + 标题 + 行高亮
@@ -237,11 +241,14 @@ renderer.table = function (token: any) {
   return `<div class="table-wrapper"><table><thead>${headerHtml}</thead><tbody>${bodyHtml}</tbody></table></div>`;
 };
 
-// 链接：外部链接自动 target="_blank"
-renderer.link = (token: any) => {
+// 链接：外部链接自动 target="_blank"（兼容 marked v15 token 结构）
+renderer.link = function (token: any) {
   const href = token.href || '';
   const title = token.title || '';
-  const text = token.text || '';
+  // 用 parseInline 解析链接文本中的 inline 格式
+  const text = token.tokens && this.parser
+    ? this.parser.parseInline(token.tokens)
+    : (token.text || '');
   const isExternal = href.startsWith("http");
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
   const externalAttrs = isExternal ? ' target="_blank" rel="noopener noreferrer"' : "";

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -221,7 +221,7 @@ renderer.table = function (token: any) {
       const align = cell.align ? ` style="text-align:${cell.align}"` : "";
       const cellText = cell.tokens
         ? this.parser.parseInline(cell.tokens)
-        : (typeof cell.text === "string" ? cell.text : String(cell));
+        : (typeof cell.text === "string" ? cell.text : "");
       return `<th${align}>${cellText}</th>`;
     }).join("") + "</tr>";
   } else if (typeof token.header === "string") {
@@ -236,7 +236,7 @@ renderer.table = function (token: any) {
         const align = cell.align ? ` style="text-align:${cell.align}"` : "";
         const cellText = cell.tokens
           ? this.parser.parseInline(cell.tokens)
-          : (typeof cell.text === "string" ? cell.text : String(cell));
+          : (typeof cell.text === "string" ? cell.text : "");
         return `<td${align}>${cellText}</td>`;
       }).join("") + "</tr>";
     }).join("");

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -141,25 +141,31 @@ renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
     return `<span class="code-line${hlClass}${diffClass}">${numHtml}<span class="line-content">${line}</span></span>`;
   }).join("\n");
 
-  // 标题栏
-  const titleBar = title
-    ? `<div class="code-title-bar"><span class="code-title-dots"><span></span><span></span><span></span></span><span class="code-title-text">${escapeHtml(title)}</span></div>`
-    : "";
 
-  const langLabel = language ? `<span class="code-lang">${language}</span>` : "";
+  const langLabel = language ? `<span class="code-lang">${language}</span>` : `<span class="code-lang">code</span>`;
 
   const copyIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+
+  const copyBtn = `<button class="copy-code-btn" aria-label="复制代码">${copyIcon}</button>`;
 
   const hasTitle = title ? " has-title" : "";
   const hasLineNums = showLineNumbers ? " has-line-numbers" : "";
 
-  return `<div class="code-block-wrapper relative group${hasTitle}${hasLineNums}">
-    ${titleBar}
-    <button class="copy-code-btn absolute ${title ? "top-[42px]" : "top-2"} right-2 flex items-center justify-center p-1.5 rounded-md border border-border/40 bg-card/60 text-muted-foreground transition-all duration-200 hover:text-foreground hover:bg-card hover:border-border/80 opacity-40 hover:opacity-100 group-hover:opacity-100 z-10" aria-label="复制代码">
-      ${copyIcon}
-    </button>
-    <pre class="hljs">${langLabel}<code class="hljs language-${language || "text"}">${codeLines}</code></pre>
-  </div>`;
+  if (title) {
+    // 有标题时：标题栏（macOS 圆点 + 标题 + 复制按钮）
+    const titleBar = `<div class="code-title-bar"><span class="code-title-dots"><span></span><span></span><span></span></span><span class="code-title-text">${escapeHtml(title)}</span>${copyBtn}</div>`;
+    return `<div class="code-block-wrapper${hasTitle}${hasLineNums}">
+      ${titleBar}
+      <pre class="hljs"><code class="hljs language-${language || "text"}">${codeLines}</code></pre>
+    </div>`;
+  } else {
+    // 无标题时：顶部信息栏（语言标签 + 复制按钮）
+    const header = `<div class="code-header">${langLabel}${copyBtn}</div>`;
+    return `<div class="code-block-wrapper has-header${hasLineNums}">
+      ${header}
+      <pre class="hljs"><code class="hljs language-${language || "text"}">${codeLines}</code></pre>
+    </div>`;
+  }
 };
 
 // 图片/视频：懒加载 + 圆角 + 视频解析

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -82,10 +82,12 @@ export function AdminDashboard() {
   };
 
   const toggleSelect = (slug: string) => {
-    const next = new Set(selectedSlugs);
-    if (next.has(slug)) next.delete(slug);
-    else next.add(slug);
-    setSelectedSlugs(next);
+    setSelectedSlugs((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
   };
 
   const handleBatchOperate = async (action: "publish" | "unpublish" | "delete") => {

--- a/client/src/pages/admin/editor.tsx
+++ b/client/src/pages/admin/editor.tsx
@@ -488,9 +488,6 @@ export function AdminEditor() {
           <button onClick={() => setZenMode(!zenMode)} title="专注模式" className="h-[30px] px-[8px] rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent/20 transition-colors">
             {zenMode ? <Minimize2 className="h-[13px] w-[13px]" /> : <Maximize2 className="h-[13px] w-[13px]" />}
           </button>
-          <button onClick={() => setShowPreview(!showPreview)} title={showPreview ? "关闭预览面板" : "打开预览面板"} className={`h-[30px] px-[8px] rounded-md inline-flex items-center gap-[4px] text-[12px] transition-colors ${showPreview ? "text-foreground bg-accent/20" : "text-muted-foreground/40 hover:text-foreground hover:bg-accent/15"}`}>
-            {showPreview ? <PanelRightClose className="h-[13px] w-[13px]" /> : <PanelRight className="h-[13px] w-[13px]" />}
-          </button>
           <label className="flex items-center gap-[5px] text-[12px] text-muted-foreground/50 cursor-pointer select-none">
             <input type="checkbox" checked={form.published} onChange={(e) => updateField("published", e.target.checked)} className="rounded accent-foreground" />
             发布
@@ -650,13 +647,22 @@ export function AdminEditor() {
                 );
               })}
             </div>
-            <div className="flex items-center gap-[4px]">
+            <div className="flex items-center gap-[2px]">
               <input type="file" ref={fileInputRef} accept="image/*" className="hidden" onChange={(e) => { if (e.target.files?.[0]) handleImageUpload(e.target.files[0]); }} />
               <button onClick={() => fileInputRef.current?.click()} disabled={uploading}
                 className="inline-flex items-center gap-[3px] h-[24px] px-[6px] rounded-[4px] text-[10px] text-muted-foreground/40 hover:text-foreground hover:bg-accent/20 transition-colors disabled:opacity-50"
               >
                 {uploading ? <Upload className="h-[10px] w-[10px] animate-pulse" /> : <Image className="h-[10px] w-[10px]" />}
                 {uploading ? "上传中" : "插图"}
+              </button>
+              <div className="w-[1px] h-[14px] bg-border/15 mx-[3px]" />
+              <button
+                onClick={() => setShowPreview(!showPreview)}
+                title={showPreview ? "关闭预览" : "打开预览"}
+                className={`inline-flex items-center gap-[3px] h-[24px] px-[6px] rounded-[4px] text-[10px] transition-colors ${showPreview ? "text-cyan-400/70 bg-cyan-500/8 hover:bg-cyan-500/12" : "text-muted-foreground/40 hover:text-foreground hover:bg-accent/20"}`}
+              >
+                {showPreview ? <Eye className="h-[10px] w-[10px]" /> : <EyeOff className="h-[10px] w-[10px]" />}
+                {showPreview ? "预览" : "预览"}
               </button>
             </div>
           </div>

--- a/client/src/pages/admin/editor.tsx
+++ b/client/src/pages/admin/editor.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useLocation } from "wouter";
 import { fetchPost, createPost, updatePost, uploadImage, localizePostImages, fetchPostVersions, restorePostVersion, type PostVersion } from "@/lib/api";
 import { renderMarkdown } from "@/lib/markdown";
-import { ArrowLeft, Save, Eye, EyeOff, Upload, Image, ChevronDown, ChevronUp, Bold, Italic, Heading2, Heading3, Link2, Code, Quote, List, ListOrdered, Minus, Maximize2, Minimize2, Table, CheckSquare, FileCode, ImageDown, History, Check, X } from "lucide-react";
+import { ArrowLeft, Save, Eye, EyeOff, Upload, Image, ChevronDown, ChevronUp, Bold, Italic, Heading2, Heading3, Link2, Code, Quote, List, ListOrdered, Minus, Maximize2, Minimize2, Table, CheckSquare, FileCode, ImageDown, History, Check, X, ArrowDownUp, PanelRightClose, PanelRight } from "lucide-react";
 import { Link } from "wouter";
 import Editor, { type Monaco } from "@monaco-editor/react";
 import type * as MonacoTypes from "monaco-editor";
@@ -136,6 +136,12 @@ export function AdminEditor() {
   const [versions, setVersions] = useState<PostVersion[]>([]);
   const [showVersions, setShowVersions] = useState(false);
   const [restoring, setRestoring] = useState(false);
+  const [syncScroll, setSyncScroll] = useState(true);
+  const syncScrollRef = useRef(true);
+  const previewRef = useRef<HTMLDivElement>(null);
+
+  // 保持 ref 与 state 同步（避免 onMount 闭包陷阱）
+  useEffect(() => { syncScrollRef.current = syncScroll; }, [syncScroll]);
 
   useEffect(() => {
     if (isEdit && params.slug) {
@@ -482,8 +488,8 @@ export function AdminEditor() {
           <button onClick={() => setZenMode(!zenMode)} title="专注模式" className="h-[30px] px-[8px] rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent/20 transition-colors">
             {zenMode ? <Minimize2 className="h-[13px] w-[13px]" /> : <Maximize2 className="h-[13px] w-[13px]" />}
           </button>
-          <button onClick={() => setShowPreview(!showPreview)} title={showPreview ? "隐藏预览" : "显示预览"} className={`h-[30px] px-[8px] rounded-md transition-colors ${showPreview ? "text-foreground bg-accent/20" : "text-muted-foreground/40 hover:text-foreground"}`}>
-            {showPreview ? <Eye className="h-[13px] w-[13px]" /> : <EyeOff className="h-[13px] w-[13px]" />}
+          <button onClick={() => setShowPreview(!showPreview)} title={showPreview ? "关闭预览面板" : "打开预览面板"} className={`h-[30px] px-[8px] rounded-md inline-flex items-center gap-[4px] text-[12px] transition-colors ${showPreview ? "text-foreground bg-accent/20" : "text-muted-foreground/40 hover:text-foreground hover:bg-accent/15"}`}>
+            {showPreview ? <PanelRightClose className="h-[13px] w-[13px]" /> : <PanelRight className="h-[13px] w-[13px]" />}
           </button>
           <label className="flex items-center gap-[5px] text-[12px] text-muted-foreground/50 cursor-pointer select-none">
             <input type="checkbox" checked={form.published} onChange={(e) => updateField("published", e.target.checked)} className="rounded accent-foreground" />
@@ -664,6 +670,19 @@ export function AdminEditor() {
               beforeMount={handleEditorWillMount}
               onMount={(editor) => {
                 editorRef.current = editor;
+                // ── 同步滚动：编辑器 → 预览 ──
+                editor.onDidScrollChange(() => {
+                  if (!syncScrollRef.current || !previewRef.current) return;
+                  const scrollTop = editor.getScrollTop();
+                  const scrollHeight = editor.getScrollHeight();
+                  const clientHeight = editor.getLayoutInfo().height;
+                  const maxScroll = scrollHeight - clientHeight;
+                  if (maxScroll <= 0) return;
+                  const ratio = scrollTop / maxScroll;
+                  const previewEl = previewRef.current;
+                  const previewMax = previewEl.scrollHeight - previewEl.clientHeight;
+                  previewEl.scrollTop = ratio * previewMax;
+                });
                 // 监听 Monaco 编辑器的 paste 事件（处理粘贴图片）
                 const domNode = editor.getDomNode();
                 if (domNode) {
@@ -720,10 +739,31 @@ export function AdminEditor() {
         {/* 右侧实时预览 */}
         {showPreview && (
           <div className="flex flex-col min-h-0 border-l border-border/15">
-            <div className="px-[12px] py-[6px] border-b border-border/15 bg-card/10 shrink-0">
-              <span className="text-[10px] text-muted-foreground/35">预览</span>
+            <div className="flex items-center justify-between px-[12px] py-[4px] border-b border-border/15 bg-card/10 shrink-0">
+              <span className="text-[10px] text-muted-foreground/35 uppercase tracking-[0.05em]">预览</span>
+              <div className="flex items-center gap-[2px]">
+                <button
+                  onClick={() => setSyncScroll(!syncScroll)}
+                  title={syncScroll ? "已开启同步滚动（点击关闭）" : "已关闭同步滚动（点击开启）"}
+                  className={`h-[24px] px-[6px] rounded-[4px] inline-flex items-center gap-[4px] text-[10px] transition-all ${
+                    syncScroll
+                      ? "text-cyan-400/80 bg-cyan-500/10 hover:bg-cyan-500/15"
+                      : "text-muted-foreground/30 hover:text-muted-foreground/50 hover:bg-accent/10"
+                  }`}
+                >
+                  <ArrowDownUp className="h-[11px] w-[11px]" />
+                  {syncScroll ? "同步" : "独立"}
+                </button>
+                <button
+                  onClick={() => setShowPreview(false)}
+                  title="关闭预览面板"
+                  className="h-[24px] px-[6px] rounded-[4px] inline-flex items-center text-muted-foreground/30 hover:text-foreground hover:bg-accent/15 transition-colors"
+                >
+                  <PanelRightClose className="h-[12px] w-[12px]" />
+                </button>
+              </div>
             </div>
-            <div className="flex-1 min-h-0 overflow-y-auto p-[24px]">
+            <div ref={previewRef} className="flex-1 min-h-0 overflow-y-auto p-[24px]">
               {form.title && (
                 <h1 className="text-[22px] font-semibold tracking-[-0.02em] mb-[16px]">{form.title}</h1>
               )}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -131,7 +131,8 @@ export function HomePage() {
 
   // 计算标签频次并按热度排序
   const tagCounts = posts.flatMap((p) => p.tags).reduce<Record<string, number>>((acc, t) => {
-    acc[t] = (acc[t] || 0) + 1;
+    if (t === "__proto__" || t === "constructor") return acc;
+    acc[t] = Object.prototype.hasOwnProperty.call(acc, t) ? acc[t] + 1 : 1;
     return acc;
   }, {});
   const sortedTags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { Hero } from "@/components/hero";
 import { ArticleCard } from "@/components/article-card";
-import { Badge } from "@/components/ui/badge";
+
 import { Separator } from "@/components/ui/separator";
 import { fetchPosts, fetchCategories, type PostMeta, type CategoryInfo } from "@/lib/api";
 import { AnimateIn } from "@/hooks/use-animate";
 import { SeoHead } from "@/components/seo-head";
-import { ExternalLink, Mail, Rss, Eye, FolderOpen } from "lucide-react";
+import { ExternalLink, Mail, Rss, Eye, FolderOpen, Hash, ChevronDown } from "lucide-react";
 
 type PublicSettings = {
   site_title: string;
@@ -27,6 +27,49 @@ type TrafficData = {
   totalPosts: number;
   chart: { date: string; count: number }[];
 };
+
+/* ── 紧凑标签云 ── */
+const TAG_VISIBLE = 15;
+function TagCloud({ tags, maxCount }: { tags: [string, number][]; maxCount: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = tags.length > TAG_VISIBLE;
+  const visible = expanded ? tags : tags.slice(0, TAG_VISIBLE);
+  return (
+    <div className="rounded-lg border border-border/40 bg-card/30 p-[20px]">
+      <h3 className="mb-[12px] text-[13px] font-medium uppercase tracking-[0.06em] text-muted-foreground/60 flex items-center gap-[5px]">
+        <Hash className="h-[12px] w-[12px]" />
+        标签
+        <span className="ml-auto text-[10px] font-mono text-muted-foreground/25 normal-case tracking-normal">{tags.length}</span>
+      </h3>
+      <div className="flex flex-wrap gap-x-[6px] gap-y-[4px] leading-[1.9]">
+        {visible.map(([tag, count]) => {
+          // 频率归一化 0~1 映射透明度与字号
+          const ratio = maxCount > 1 ? (count - 1) / (maxCount - 1) : 0;
+          const opacity = 0.35 + ratio * 0.55; // 0.35 ~ 0.90
+          const size = 11 + ratio * 3; // 11px ~ 14px
+          return (
+            <span
+              key={tag}
+              className="cursor-pointer whitespace-nowrap transition-colors duration-200 hover:text-foreground"
+              style={{ fontSize: `${size}px`, color: `oklch(0.85 0.01 240 / ${opacity})` }}
+              title={`${tag}（${count} 篇）`}
+            >
+              {tag}
+            </span>
+          );
+        })}
+      </div>
+      {hasMore && !expanded && (
+        <button
+          onClick={() => setExpanded(true)}
+          className="mt-[8px] inline-flex items-center gap-[3px] text-[11px] text-muted-foreground/30 transition-colors hover:text-muted-foreground/60"
+        >
+          展开全部 <ChevronDown className="h-[11px] w-[11px]" />
+        </button>
+      )}
+    </div>
+  );
+}
 
 /* ── 纯 SVG 迷你折线图 ── */
 function SparkLine({ data, width = 240, height = 48 }: { data: number[]; width?: number; height?: number }) {
@@ -86,7 +129,13 @@ export function HomePage() {
     fetchCategories().then(setCategories).catch(() => {});
   }, []);
 
-  const allTags = Array.from(new Set(posts.flatMap((p) => p.tags)));
+  // 计算标签频次并按热度排序
+  const tagCounts = posts.flatMap((p) => p.tags).reduce<Record<string, number>>((acc, t) => {
+    acc[t] = (acc[t] || 0) + 1;
+    return acc;
+  }, {});
+  const sortedTags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
+  const maxTagCount = sortedTags.length > 0 ? sortedTags[0][1] : 1;
 
   const authorName = settings?.author_name || "Monolith";
   const authorTitle = settings?.author_title || "独立开发者";
@@ -174,16 +223,9 @@ export function HomePage() {
             </AnimateIn>
 
             {/* ── 标签云（无标签时隐藏） ── */}
-            {allTags.length > 0 && (
+            {sortedTags.length > 0 && (
               <AnimateIn animation="animate-fade-in" delay="delay-3">
-                <div className="rounded-lg border border-border/40 bg-card/30 p-[20px]">
-                  <h3 className="mb-[12px] text-[13px] font-medium uppercase tracking-[0.06em] text-muted-foreground/60">标签</h3>
-                  <div className="flex flex-wrap gap-[6px]">
-                    {allTags.map((tag) => (
-                      <Badge key={tag} variant="outline" className="h-[24px] rounded-[4px] px-[8px] text-[12px] font-normal text-muted-foreground transition-colors duration-200 hover:bg-accent hover:text-foreground cursor-pointer">{tag}</Badge>
-                    ))}
-                  </div>
-                </div>
+                <TagCloud tags={sortedTags} maxCount={maxTagCount} />
               </AnimateIn>
             )}
             {/* ── 分类（无分类时隐藏） ── */}

--- a/client/src/pages/post.tsx
+++ b/client/src/pages/post.tsx
@@ -48,22 +48,38 @@ export function PostPage() {
 
   useEffect(() => {
     if (!params.slug) return;
+    
+    // 路由跳转时如果不带锚点，强制回到顶部
+    if (!window.location.hash) {
+      window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+    }
+    
+    setLoading(true);
     fetchPost(params.slug)
       .then(setPost)
       .catch(() => setError("文章未找到"))
       .finally(() => setLoading(false));
   }, [params.slug]);
 
-  // 提取标题列表（用于 TOC）
-  const headings = useMemo(() => {
-    if (!post) return [];
-    return extractHeadings(post.content);
-  }, [post]);
+  // 提取标题列表（用于 TOC）和 Markdown 渲染
+  const [headings, setHeadings] = useState<{ id: string; text: string; level: number }[]>([]);
+  const [htmlContent, setHtmlContent] = useState("");
 
-  // 渲染 Markdown HTML
-  const htmlContent = useMemo(() => {
-    if (!post) return "";
-    return renderMarkdown(post.content);
+  useEffect(() => {
+    if (!post) {
+      setHeadings([]);
+      setHtmlContent("");
+      return;
+    }
+    
+    // 利用 setTimeout 将密集的 Markdown 解析与语法高亮推迟到下一个事件循环
+    // 从而让浏览器能立刻绘制页面基本框架和动画，大幅提升用户感知速度
+    const timer = setTimeout(() => {
+      setHeadings(extractHeadings(post.content));
+      setHtmlContent(renderMarkdown(post.content));
+    }, 10);
+    
+    return () => clearTimeout(timer);
   }, [post]);
 
   // 图片渐进淡入（Intersection Observer）

--- a/client/src/pages/post.tsx
+++ b/client/src/pages/post.tsx
@@ -6,6 +6,7 @@ import { Separator } from "@/components/ui/separator";
 import { fetchPost, type Post } from "@/lib/api";
 import { renderMarkdown, extractHeadings } from "@/lib/markdown";
 import { ArrowLeft, Eye, BookOpen, X } from "lucide-react";
+import { ReadingControls, useReadingPreferences } from "@/components/reading-controls";
 import { TableOfContents, ReadingProgressBar } from "@/components/toc";
 import { SeoHead } from "@/components/seo-head";
 import { CommentsSection } from "@/components/comments";
@@ -24,27 +25,39 @@ export function PostPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [readingMode, setReadingMode] = useState(false);
+  const { preferences, updatePreference } = useReadingPreferences();
 
   // 阅读模式切换
   const toggleReadingMode = useCallback(() => {
-    setReadingMode((prev) => {
-      const next = !prev;
-      document.documentElement.classList.toggle("reading-mode", next);
-      return next;
-    });
+    setReadingMode((prev) => !prev);
   }, []);
 
   // ESC 退出阅读模式
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && readingMode) toggleReadingMode();
+      if (e.key === "Escape" && readingMode) setReadingMode(false);
     };
     window.addEventListener("keydown", handleKey);
     return () => {
       window.removeEventListener("keydown", handleKey);
-      document.documentElement.classList.remove("reading-mode");
     };
-  }, [readingMode, toggleReadingMode]);
+  }, [readingMode]);
+
+  // 处理阅读模式样式与属性
+  useEffect(() => {
+    document.documentElement.classList.toggle("reading-mode", readingMode);
+    
+    if (readingMode && preferences.theme !== "system") {
+      document.documentElement.setAttribute("data-reading-theme", preferences.theme);
+    } else {
+      document.documentElement.removeAttribute("data-reading-theme");
+    }
+
+    return () => {
+      document.documentElement.classList.remove("reading-mode");
+      document.documentElement.removeAttribute("data-reading-theme");
+    };
+  }, [readingMode, preferences.theme]);
 
   useEffect(() => {
     if (!params.slug) return;
@@ -156,21 +169,29 @@ export function PostPage() {
       <ReadingProgressBar />
 
       {/* 三栏布局容器：文章 + TOC 侧边栏 */}
-      <div className="post-layout mx-auto w-full max-w-[1100px] px-[16px] lg:px-[24px]">
+      <div 
+        className="post-layout mx-auto w-full max-w-[1100px] px-[16px] lg:px-[24px]"
+        style={readingMode ? {
+          "--rm-width": `${preferences.maxWidth}px`,
+          "--rm-font": preferences.fontFamily === "serif" ? "ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif" : "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+          "--rm-size": `${preferences.fontSize}px`,
+          "--rm-line-height": preferences.lineHeight,
+        } as React.CSSProperties : undefined}
+      >
         {/* 主内容区 */}
         <article className="post-content py-[32px] lg:py-[56px]">
           <Link href="/" className="mb-[32px] inline-flex items-center gap-[6px] text-[13px] text-muted-foreground/60 transition-all duration-200 hover:text-foreground hover:-translate-x-[2px] animate-fade-in">
             <ArrowLeft className="h-[14px] w-[14px]" />返回首页
           </Link>
 
-          {/* 阅读模式按钮 */}
+          {/* 进入阅读模式按钮 */}
           <button
             onClick={toggleReadingMode}
             className="reading-mode-toggle mb-[24px] inline-flex items-center gap-[6px] rounded-full border border-border/30 bg-card/40 px-[14px] py-[6px] text-[12px] text-muted-foreground/60 transition-all duration-300 hover:bg-card hover:text-foreground hover:border-border/60 animate-fade-in"
-            title="切换阅读模式 (ESC 退出)"
+            title="进入专注阅读模式"
           >
             <BookOpen className="h-[14px] w-[14px]" />
-            {readingMode ? "退出阅读模式" : "阅读模式"}
+            阅读模式
           </button>
 
           <header className="mb-[32px] animate-fade-in-up delay-1">
@@ -254,17 +275,13 @@ export function PostPage() {
           <TableOfContents headings={headings} />
         )}
       </div>
-
-      {/* 阅读模式浮动退出按钮 */}
-      {readingMode && (
-        <button
-          onClick={toggleReadingMode}
-          className="reading-mode-exit-fab"
-          title="退出阅读模式 (ESC)"
-        >
-          <X className="h-[16px] w-[16px]" />
-        </button>
-      )}
+      {/* 阅读模式控制面板 */}
+      <ReadingControls
+        isActive={readingMode}
+        onClose={() => setReadingMode(false)}
+        preferences={preferences}
+        updatePreference={updatePreference}
+      />
     </>
   );
 }

--- a/client/src/pages/post.tsx
+++ b/client/src/pages/post.tsx
@@ -180,19 +180,19 @@ export function PostPage() {
       >
         {/* 主内容区 */}
         <article className="post-content py-[32px] lg:py-[56px]">
-          <Link href="/" className="mb-[32px] inline-flex items-center gap-[6px] text-[13px] text-muted-foreground/60 transition-all duration-200 hover:text-foreground hover:-translate-x-[2px] animate-fade-in">
-            <ArrowLeft className="h-[14px] w-[14px]" />返回首页
-          </Link>
-
-          {/* 进入阅读模式按钮 */}
-          <button
-            onClick={toggleReadingMode}
-            className="reading-mode-toggle mb-[24px] inline-flex items-center gap-[6px] rounded-full border border-border/30 bg-card/40 px-[14px] py-[6px] text-[12px] text-muted-foreground/60 transition-all duration-300 hover:bg-card hover:text-foreground hover:border-border/60 animate-fade-in"
-            title="进入专注阅读模式"
-          >
-            <BookOpen className="h-[14px] w-[14px]" />
-            阅读模式
-          </button>
+          <div className="mb-[32px] flex items-center justify-between animate-fade-in">
+            <Link href="/" className="inline-flex items-center gap-[6px] text-[13px] text-muted-foreground/60 transition-all duration-200 hover:text-foreground hover:-translate-x-[2px]">
+              <ArrowLeft className="h-[14px] w-[14px]" />返回首页
+            </Link>
+            <button
+              onClick={toggleReadingMode}
+              className="reading-mode-toggle inline-flex items-center gap-[5px] text-[12px] text-muted-foreground/40 transition-all duration-200 hover:text-foreground/70"
+              title="进入专注阅读模式"
+            >
+              <BookOpen className="h-[13px] w-[13px]" />
+              专注阅读
+            </button>
+          </div>
 
           <header className="mb-[32px] animate-fade-in-up delay-1">
             <div className={`mb-[24px] h-[3px] w-[60px] rounded-full bg-gradient-to-r ${post.coverColor || "from-gray-500/20 to-gray-600/20"}`} />

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1174 @@
+{
+  "name": "monolith-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "monolith-mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "zod": "^3.25.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.17.57",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "monolith-mcp-server",
+  "version": "1.0.0",
+  "description": "Monolith 博客专属 MCP 服务器 — 全权管理文章、评论、媒体、设置、备份等",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.25.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "@types/node": "^20.17.57"
+  }
+}

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -7,6 +7,20 @@
 let cachedToken: string | null = null;
 let tokenExpiresAt = 0; // Unix 时间戳（秒）
 
+/** 解析 JWT Payload */
+function parseJwt(token: string) {
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+    return JSON.parse(jsonPayload);
+  } catch (e) {
+    return null;
+  }
+}
+
 /** 从环境变量读取配置 */
 function getConfig() {
   const apiUrl = process.env.MONOLITH_API_URL;
@@ -25,24 +39,39 @@ function getConfig() {
 async function login(): Promise<string> {
   const { apiUrl, password } = getConfig();
 
-  const res = await fetch(`${apiUrl}/api/auth/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ password }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
 
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`登录失败 (${res.status}): ${body}`);
+  try {
+    const res = await fetch(`${apiUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`登录失败 (${res.status}): ${body}`);
+    }
+
+    const data = (await res.json()) as { token: string };
+    cachedToken = data.token;
+    
+    // 解析 JWT 获取 exp 字段，提前 5 分钟刷新
+    const payload = parseJwt(data.token);
+    if (payload && payload.exp) {
+      tokenExpiresAt = payload.exp - 300;
+    } else {
+      // 回退策略：默认 7 天
+      tokenExpiresAt = Math.floor(Date.now() / 1000) + 7 * 24 * 3600 - 300;
+    }
+
+    console.error("[Monolith MCP] 认证成功，JWT Token 已缓存。");
+    return cachedToken;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  const data = (await res.json()) as { token: string };
-  cachedToken = data.token;
-  // JWT 有效期 7 天，提前 1 小时刷新
-  tokenExpiresAt = Math.floor(Date.now() / 1000) + 7 * 24 * 3600 - 3600;
-
-  console.error("[Monolith MCP] 认证成功，JWT Token 已缓存。");
-  return cachedToken;
 }
 
 /** 获取有效的 Token（自动登录/续签） */
@@ -62,9 +91,11 @@ export async function apiRequest<T = unknown>(
     body?: unknown;
     query?: Record<string, string | number | boolean | undefined>;
     auth?: boolean; // 默认 true，公开 API 可设为 false
-  } = {}
+    timeoutMs?: number; // 请求超时时间
+  } = {},
+  isRetry = false
 ): Promise<T> {
-  const { method = "GET", body, query, auth = true } = options;
+  const { method = "GET", body, query, auth = true, timeoutMs = 15000 } = options;
   const { apiUrl } = getConfig();
 
   // 构建完整 URL
@@ -90,23 +121,43 @@ export async function apiRequest<T = unknown>(
     headers["Authorization"] = `Bearer ${token}`;
   }
 
-  // 发起请求
-  const res = await fetch(url, {
-    method,
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
-  if (!res.ok) {
-    const errorText = await res.text();
-    throw new Error(`API 请求失败 ${method} ${path} (${res.status}): ${errorText}`);
+  try {
+    // 发起请求
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+
+    // 处理 401: Token 失效时重试一次
+    if (res.status === 401 && auth && !isRetry) {
+      console.error("[Monolith MCP] Token 失效，尝试重新登录并重试请求...");
+      cachedToken = null; // 清除缓存强制重新登录
+      return apiRequest(path, options, true);
+    }
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      throw new Error(`API 请求失败 ${method} ${path} (${res.status}): ${errorText}`);
+    }
+
+    // 空响应兼容
+    const contentType = res.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return (await res.json()) as T;
+    }
+
+    return (await res.text()) as unknown as T;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`API 请求超时 ${method} ${path} (${timeoutMs}ms)`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
-
-  // 空响应兼容
-  const contentType = res.headers.get("content-type") || "";
-  if (contentType.includes("application/json")) {
-    return (await res.json()) as T;
-  }
-
-  return (await res.text()) as unknown as T;
 }

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -1,0 +1,112 @@
+/* ──────────────────────────────────────────────
+   Monolith MCP 服务器 — HTTP 客户端
+   封装认证逻辑与请求方法，自动管理 JWT 生命周期
+   ────────────────────────────────────────────── */
+
+/** 缓存的认证令牌与过期时间 */
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0; // Unix 时间戳（秒）
+
+/** 从环境变量读取配置 */
+function getConfig() {
+  const apiUrl = process.env.MONOLITH_API_URL;
+  const password = process.env.MONOLITH_PASSWORD;
+
+  if (!apiUrl || !password) {
+    throw new Error(
+      "缺少环境变量 MONOLITH_API_URL 或 MONOLITH_PASSWORD，请在 MCP 配置中设置。"
+    );
+  }
+
+  return { apiUrl: apiUrl.replace(/\/$/, ""), password };
+}
+
+/** 登录获取 JWT Token */
+async function login(): Promise<string> {
+  const { apiUrl, password } = getConfig();
+
+  const res = await fetch(`${apiUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ password }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`登录失败 (${res.status}): ${body}`);
+  }
+
+  const data = (await res.json()) as { token: string };
+  cachedToken = data.token;
+  // JWT 有效期 7 天，提前 1 小时刷新
+  tokenExpiresAt = Math.floor(Date.now() / 1000) + 7 * 24 * 3600 - 3600;
+
+  console.error("[Monolith MCP] 认证成功，JWT Token 已缓存。");
+  return cachedToken;
+}
+
+/** 获取有效的 Token（自动登录/续签） */
+async function getToken(): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedToken && now < tokenExpiresAt) {
+    return cachedToken;
+  }
+  return login();
+}
+
+/** 通用请求方法 */
+export async function apiRequest<T = unknown>(
+  path: string,
+  options: {
+    method?: string;
+    body?: unknown;
+    query?: Record<string, string | number | boolean | undefined>;
+    auth?: boolean; // 默认 true，公开 API 可设为 false
+  } = {}
+): Promise<T> {
+  const { method = "GET", body, query, auth = true } = options;
+  const { apiUrl } = getConfig();
+
+  // 构建完整 URL
+  let url = `${apiUrl}${path}`;
+  if (query) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== "") {
+        params.set(key, String(value));
+      }
+    }
+    const qs = params.toString();
+    if (qs) url += `?${qs}`;
+  }
+
+  // 构建请求头
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (auth) {
+    const token = await getToken();
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  // 发起请求
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`API 请求失败 ${method} ${path} (${res.status}): ${errorText}`);
+  }
+
+  // 空响应兼容
+  const contentType = res.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return (await res.json()) as T;
+  }
+
+  return (await res.text()) as unknown as T;
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/* ──────────────────────────────────────────────
+   Monolith MCP 服务器 — 入口
+   
+   为 Monolith 博客提供 30 个 MCP 工具，涵盖：
+   文章 · 评论 · 媒体 · 统计 · 设置 · 页面 · 分类 · 备份
+   
+   通过 stdio 传输运行，由宿主 AI 编辑器调用。
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { registerPostTools } from "./tools/posts.js";
+import { registerCommentTools } from "./tools/comments.js";
+import { registerMediaTools } from "./tools/media.js";
+import { registerAnalyticsTools } from "./tools/analytics.js";
+import { registerSettingsTools } from "./tools/settings.js";
+import { registerPageTools } from "./tools/pages.js";
+import { registerTaxonomyTools } from "./tools/taxonomy.js";
+import { registerBackupTools } from "./tools/backup.js";
+
+async function main() {
+  // 创建 MCP 服务器实例
+  const server = new McpServer(
+    {
+      name: "monolith-blog",
+      version: "1.0.0",
+    },
+    {
+      capabilities: { logging: {} },
+      instructions: [
+        "这是 Monolith 博客的专属管理 MCP 服务器。",
+        "你可以通过以下工具全权管理博客的内容与配置：",
+        "",
+        "📝 文章：list_posts, get_post, create_post, update_post, delete_post, batch_posts, search_posts, list_post_versions",
+        "💬 评论：list_comments, approve_comment, delete_comment",
+        "🖼️ 媒体：list_media, upload_media, delete_media",
+        "📊 统计：get_dashboard_stats, get_analytics, get_traffic",
+        "⚙️ 设置：get_settings, update_settings",
+        "📄 页面：list_pages, get_page, upsert_page, delete_page",
+        "🏷️ 分类：list_tags, list_categories, get_series",
+        "💾 备份：export_backup, backup_to_r2, list_r2_backups, restore_backup",
+        "",
+        "⚠️ 安全规则：",
+        "- 标记为【高危操作】的工具（delete_*, batch_posts, restore_backup）执行前必须向用户确认",
+        "- restore_backup 会自动在恢复前创建安全快照",
+        "- create_post 默认创建草稿状态，需显式设置 status='published' 才会立即发布",
+      ].join("\n"),
+    }
+  );
+
+  // 注册所有工具模块
+  registerPostTools(server);
+  registerCommentTools(server);
+  registerMediaTools(server);
+  registerAnalyticsTools(server);
+  registerSettingsTools(server);
+  registerPageTools(server);
+  registerTaxonomyTools(server);
+  registerBackupTools(server);
+
+  // 启动 stdio 传输
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error("🏠 Monolith MCP 服务器已启动 (stdio)，共注册 30 个工具。");
+}
+
+main().catch((error) => {
+  console.error("❌ Monolith MCP 服务器启动失败:", error);
+  process.exit(1);
+});

--- a/mcp-server/src/tools/analytics.ts
+++ b/mcp-server/src/tools/analytics.ts
@@ -1,0 +1,61 @@
+/* ──────────────────────────────────────────────
+   统计分析工具 (Analytics)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerAnalyticsTools(server: McpServer) {
+  // ── 仪表盘摘要 ──
+  server.tool(
+    "get_dashboard_stats",
+    "获取博客仪表盘摘要：总文章数、总浏览量、总评论数、最近文章列表",
+    {},
+    async () => {
+      const stats = await apiRequest("/api/admin/stats");
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(stats, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 访问分析 ──
+  server.tool(
+    "get_analytics",
+    "获取详细的访问分析数据，可指定时间范围",
+    {
+      days: z.number().default(30).describe("查询最近多少天的数据"),
+    },
+    async ({ days }) => {
+      const analytics = await apiRequest("/api/admin/analytics", {
+        query: { days },
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(analytics, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 公开流量统计 ──
+  server.tool(
+    "get_traffic",
+    "获取公开的流量统计数据（无需认证）",
+    {},
+    async () => {
+      const traffic = await apiRequest("/api/stats/traffic", { auth: false });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(traffic, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/tools/backup.ts
+++ b/mcp-server/src/tools/backup.ts
@@ -76,7 +76,14 @@ export function registerBackupTools(server: McpServer) {
         await apiRequest("/api/admin/backup/r2", { method: "POST" });
         console.error("[Monolith MCP] 安全快照已创建。");
       } catch (e) {
-        console.error("[Monolith MCP] 安全快照创建失败，继续恢复操作...", e);
+        console.error("[Monolith MCP] 安全快照创建失败", e);
+        return {
+          content: [{
+            type: "text" as const,
+            text: "❌ 安全快照创建失败，为防止数据丢失，已终止恢复操作。",
+          }],
+          isError: true,
+        };
       }
 
       // 执行恢复

--- a/mcp-server/src/tools/backup.ts
+++ b/mcp-server/src/tools/backup.ts
@@ -1,0 +1,108 @@
+/* ──────────────────────────────────────────────
+   备份恢复工具 (Backup)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerBackupTools(server: McpServer) {
+  // ── 导出 JSON 备份 ──
+  server.tool(
+    "export_backup",
+    "导出博客全部数据为 JSON 格式（文章、评论、设置、页面等）",
+    {},
+    async () => {
+      const backup = await apiRequest("/api/admin/backup/export");
+      const text = typeof backup === 'string' ? backup : JSON.stringify(backup, null, 2);
+      // 截断过长输出避免 MCP 消息超限
+      const truncated = text.length > 50000
+        ? text.slice(0, 50000) + "\n\n... [数据已截断，完整备份请通过 backup_to_r2 工具推送到云端]"
+        : text;
+      return {
+        content: [{
+          type: "text" as const,
+          text: truncated,
+        }],
+      };
+    }
+  );
+
+  // ── 备份到 R2 ──
+  server.tool(
+    "backup_to_r2",
+    "将当前博客数据备份到 R2 对象存储（云端安全快照）",
+    {},
+    async () => {
+      const result = await apiRequest("/api/admin/backup/r2", {
+        method: "POST",
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 数据已备份到 R2 云端：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 列出 R2 备份 ──
+  server.tool(
+    "list_r2_backups",
+    "列出 R2 存储中所有备份快照（含时间戳和大小）",
+    {},
+    async () => {
+      const backups = await apiRequest("/api/admin/backup/r2-list");
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(backups, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 从备份恢复 ──
+  server.tool(
+    "restore_backup",
+    "⚠️ 【超高危操作】从 JSON 数据恢复整个博客！会覆盖现有数据！执行前会自动创建 R2 安全快照。调用前请务必向主人二次确认！",
+    {
+      backupJson: z.string().describe("完整的备份 JSON 字符串"),
+    },
+    async ({ backupJson }) => {
+      // 安全防线：恢复前自动备份
+      console.error("[Monolith MCP] 恢复操作前自动创建安全快照...");
+      try {
+        await apiRequest("/api/admin/backup/r2", { method: "POST" });
+        console.error("[Monolith MCP] 安全快照已创建。");
+      } catch (e) {
+        console.error("[Monolith MCP] 安全快照创建失败，继续恢复操作...", e);
+      }
+
+      // 执行恢复
+      let data: unknown;
+      try {
+        data = JSON.parse(backupJson);
+      } catch {
+        return {
+          content: [{
+            type: "text" as const,
+            text: "❌ 备份 JSON 格式无效，请检查后重试。",
+          }],
+          isError: true,
+        };
+      }
+
+      const result = await apiRequest("/api/admin/backup/restore", {
+        method: "POST",
+        body: data,
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 数据恢复完成：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/tools/comments.ts
+++ b/mcp-server/src/tools/comments.ts
@@ -1,0 +1,65 @@
+/* ──────────────────────────────────────────────
+   评论管理工具 (Comments)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerCommentTools(server: McpServer) {
+  // ── 列出所有评论 ──
+  server.tool(
+    "list_comments",
+    "列出博客所有评论（含待审核），返回评论者、内容、审核状态、所属文章等",
+    {
+      status: z.enum(["all", "pending", "approved"]).default("all").describe("筛选状态"),
+    },
+    async ({ status }) => {
+      const comments = await apiRequest("/api/admin/comments", {
+        query: status !== "all" ? { status } : undefined,
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(comments, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 审批评论 ──
+  server.tool(
+    "approve_comment",
+    "审批通过一条待审核的评论",
+    { id: z.number().describe("评论 ID") },
+    async ({ id }) => {
+      const result = await apiRequest(`/api/admin/comments/${id}/approve`, {
+        method: "POST",
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 评论 #${id} 已审批通过。${JSON.stringify(result)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 删除评论 ──
+  server.tool(
+    "delete_comment",
+    "⚠️ 【高危操作】永久删除一条评论，此操作不可逆！调用前请确认。",
+    { id: z.number().describe("评论 ID") },
+    async ({ id }) => {
+      const result = await apiRequest(`/api/admin/comments/${id}`, {
+        method: "DELETE",
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `🗑️ 评论 #${id} 已删除。${JSON.stringify(result)}`,
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/tools/comments.ts
+++ b/mcp-server/src/tools/comments.ts
@@ -49,8 +49,14 @@ export function registerCommentTools(server: McpServer) {
   server.tool(
     "delete_comment",
     "⚠️ 【高危操作】永久删除一条评论，此操作不可逆！调用前请确认。",
-    { id: z.number().describe("评论 ID") },
-    async ({ id }) => {
+    { 
+      id: z.number().describe("评论 ID"),
+      confirm: z.enum(["yes"]).describe("必须输入 'yes' 确认高危操作")
+    },
+    async ({ id, confirm }) => {
+      if (confirm !== "yes") {
+        return { content: [{ type: "text" as const, text: "❌ 操作已取消：未确认高危操作。" }], isError: true };
+      }
       const result = await apiRequest(`/api/admin/comments/${id}`, {
         method: "DELETE",
       });

--- a/mcp-server/src/tools/media.ts
+++ b/mcp-server/src/tools/media.ts
@@ -48,30 +48,43 @@ export function registerMediaTools(server: McpServer) {
       const formData = new FormData();
       formData.append("file", blob, filename);
 
-      const res = await fetch(`${apiUrl}/api/admin/upload`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-        body: formData,
-      });
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 30000); // 媒体上传 30s 超时
 
-      if (!res.ok) {
-        const errorText = await res.text();
+      try {
+        const res = await fetch(`${apiUrl}/api/admin/upload`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          body: formData,
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          const errorText = await res.text();
+          return {
+            content: [{
+              type: "text" as const,
+              text: `❌ 上传失败 (${res.status}): ${errorText}`,
+            }],
+            isError: true,
+          };
+        }
+
+        const result = await res.json();
         return {
           content: [{
             type: "text" as const,
-            text: `❌ 上传失败 (${res.status}): ${errorText}`,
+            text: `✅ 文件 "${filename}" 上传成功：${JSON.stringify(result, null, 2)}`,
           }],
-          isError: true,
         };
+      } catch (err: any) {
+        if (err.name === "AbortError") {
+          return { content: [{ type: "text" as const, text: "❌ 上传超时 (30s)" }], isError: true };
+        }
+        throw err;
+      } finally {
+        clearTimeout(timeoutId);
       }
-
-      const result = await res.json();
-      return {
-        content: [{
-          type: "text" as const,
-          text: `✅ 文件 "${filename}" 上传成功：${JSON.stringify(result, null, 2)}`,
-        }],
-      };
     }
   );
 
@@ -79,9 +92,15 @@ export function registerMediaTools(server: McpServer) {
   server.tool(
     "delete_media",
     "⚠️ 【高危操作】删除对象存储中的指定文件，此操作不可逆！",
-    { key: z.string().describe("文件的存储 Key（路径）") },
-    async ({ key }) => {
-      const result = await apiRequest(`/api/admin/media/${key}`, {
+    { 
+      key: z.string().describe("文件的存储 Key（路径）"),
+      confirm: z.enum(["yes"]).describe("必须输入 'yes' 确认高危操作")
+    },
+    async ({ key, confirm }) => {
+      if (confirm !== "yes") {
+        return { content: [{ type: "text" as const, text: "❌ 操作已取消：未确认高危操作。" }], isError: true };
+      }
+      const result = await apiRequest(`/api/admin/media/${encodeURIComponent(key)}`, {
         method: "DELETE",
       });
       return {

--- a/mcp-server/src/tools/media.ts
+++ b/mcp-server/src/tools/media.ts
@@ -1,0 +1,121 @@
+/* ──────────────────────────────────────────────
+   媒体管理工具 (Media)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerMediaTools(server: McpServer) {
+  // ── 列出媒体库 ──
+  server.tool(
+    "list_media",
+    "列出对象存储（R2/S3）中的所有媒体文件，包含文件名、大小、上传时间和 URL",
+    {
+      page: z.number().default(1).describe("页码"),
+      limit: z.number().default(50).describe("每页数量"),
+    },
+    async ({ page, limit }) => {
+      const media = await apiRequest("/api/admin/media", {
+        query: { page, limit },
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(media, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 上传媒体（base64） ──
+  server.tool(
+    "upload_media",
+    "上传文件到对象存储。由于 MCP 限制，需将文件内容以 base64 编码传入。适合上传小型图片或文本文件。",
+    {
+      filename: z.string().describe("文件名，如 photo.jpg"),
+      base64Content: z.string().describe("文件内容的 base64 编码"),
+      contentType: z.string().default("application/octet-stream").describe("MIME 类型"),
+    },
+    async ({ filename, base64Content, contentType }) => {
+      // 将 base64 转为二进制并通过 multipart 上传
+      const { apiUrl, password: _ } = getConfigForUpload();
+      const token = await getTokenForUpload();
+
+      const buffer = Buffer.from(base64Content, "base64");
+      const blob = new Blob([buffer], { type: contentType });
+
+      const formData = new FormData();
+      formData.append("file", blob, filename);
+
+      const res = await fetch(`${apiUrl}/api/admin/upload`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const errorText = await res.text();
+        return {
+          content: [{
+            type: "text" as const,
+            text: `❌ 上传失败 (${res.status}): ${errorText}`,
+          }],
+          isError: true,
+        };
+      }
+
+      const result = await res.json();
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 文件 "${filename}" 上传成功：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 删除媒体 ──
+  server.tool(
+    "delete_media",
+    "⚠️ 【高危操作】删除对象存储中的指定文件，此操作不可逆！",
+    { key: z.string().describe("文件的存储 Key（路径）") },
+    async ({ key }) => {
+      const result = await apiRequest(`/api/admin/media/${key}`, {
+        method: "DELETE",
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `🗑️ 媒体文件 "${key}" 已删除。${JSON.stringify(result)}`,
+        }],
+      };
+    }
+  );
+}
+
+// ── 上传专用：需要直接访问 config 和 token ──
+function getConfigForUpload() {
+  const apiUrl = process.env.MONOLITH_API_URL?.replace(/\/$/, "") || "";
+  const password = process.env.MONOLITH_PASSWORD || "";
+  return { apiUrl, password };
+}
+
+let _uploadToken: string | null = null;
+let _uploadTokenExp = 0;
+
+async function getTokenForUpload(): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  if (_uploadToken && now < _uploadTokenExp) return _uploadToken;
+
+  const { apiUrl, password } = getConfigForUpload();
+  const res = await fetch(`${apiUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ password }),
+  });
+  const data = (await res.json()) as { token: string };
+  _uploadToken = data.token;
+  _uploadTokenExp = now + 7 * 24 * 3600 - 3600;
+  return _uploadToken;
+}

--- a/mcp-server/src/tools/pages.ts
+++ b/mcp-server/src/tools/pages.ts
@@ -29,7 +29,7 @@ export function registerPageTools(server: McpServer) {
     "获取指定 slug 的独立页面完整内容",
     { slug: z.string().describe("页面 slug") },
     async ({ slug }) => {
-      const page = await apiRequest(`/api/admin/pages/${slug}`);
+      const page = await apiRequest(`/api/admin/pages/${encodeURIComponent(slug)}`);
       return {
         content: [{
           type: "text" as const,
@@ -69,8 +69,14 @@ export function registerPageTools(server: McpServer) {
   server.tool(
     "delete_page",
     "⚠️ 【高危操作】永久删除指定的独立页面，此操作不可逆！",
-    { slug: z.string().describe("要删除的页面 slug") },
-    async ({ slug }) => {
+    { 
+      slug: z.string().describe("要删除的页面 slug"),
+      confirm: z.enum(["yes"]).describe("必须输入 'yes' 确认高危操作")
+    },
+    async ({ slug, confirm }) => {
+      if (confirm !== "yes") {
+        return { content: [{ type: "text" as const, text: "❌ 操作已取消：未确认高危操作。" }], isError: true };
+      }
       const result = await apiRequest("/api/admin/pages/delete", {
         method: "POST",
         body: { slug },

--- a/mcp-server/src/tools/pages.ts
+++ b/mcp-server/src/tools/pages.ts
@@ -1,0 +1,86 @@
+/* ──────────────────────────────────────────────
+   独立页面管理工具 (Pages)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerPageTools(server: McpServer) {
+  // ── 列出所有独立页 ──
+  server.tool(
+    "list_pages",
+    "列出所有独立页面（含未发布），返回标题、slug、状态、排序等",
+    {},
+    async () => {
+      const pages = await apiRequest("/api/admin/pages");
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(pages, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 获取单个独立页 ──
+  server.tool(
+    "get_page",
+    "获取指定 slug 的独立页面完整内容",
+    { slug: z.string().describe("页面 slug") },
+    async ({ slug }) => {
+      const page = await apiRequest(`/api/admin/pages/${slug}`);
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(page, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 创建/更新独立页 ──
+  server.tool(
+    "upsert_page",
+    "创建或更新一个独立页面（如关于页、友链页等）",
+    {
+      slug: z.string().describe("页面 slug"),
+      title: z.string().describe("页面标题"),
+      content: z.string().describe("Markdown 正文"),
+      status: z.enum(["published", "draft"]).default("draft").describe("发布状态"),
+      showInNav: z.boolean().default(false).describe("是否在导航栏显示"),
+      sortOrder: z.number().default(0).describe("导航排序"),
+    },
+    async (params) => {
+      const result = await apiRequest("/api/admin/pages", {
+        method: "POST",
+        body: params,
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 独立页 "${params.slug}" 已保存：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 删除独立页 ──
+  server.tool(
+    "delete_page",
+    "⚠️ 【高危操作】永久删除指定的独立页面，此操作不可逆！",
+    { slug: z.string().describe("要删除的页面 slug") },
+    async ({ slug }) => {
+      const result = await apiRequest("/api/admin/pages/delete", {
+        method: "POST",
+        body: { slug },
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `🗑️ 独立页 "${slug}" 已删除。${JSON.stringify(result)}`,
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/tools/posts.ts
+++ b/mcp-server/src/tools/posts.ts
@@ -1,0 +1,182 @@
+/* ──────────────────────────────────────────────
+   文章管理工具 (Posts)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerPostTools(server: McpServer) {
+  // ── 列出所有文章（含草稿）──
+  server.tool(
+    "list_posts",
+    "列出博客所有文章（含草稿与定时发布），返回标题、slug、状态、标签、浏览量等信息",
+    {},
+    async () => {
+      const posts = await apiRequest<unknown[]>("/api/admin/posts");
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(posts, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 获取单篇文章 ──
+  server.tool(
+    "get_post",
+    "获取指定 slug 的文章完整内容（含 Markdown 正文、元信息）",
+    { slug: z.string().describe("文章的 URL 标识符 (slug)") },
+    async ({ slug }) => {
+      const post = await apiRequest(`/api/posts/${slug}`, { auth: false });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(post, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 搜索文章 ──
+  server.tool(
+    "search_posts",
+    "根据关键词搜索文章标题和内容",
+    { query: z.string().describe("搜索关键词") },
+    async ({ query }) => {
+      const results = await apiRequest("/api/search", {
+        auth: false,
+        query: { q: query },
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(results, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 创建文章 ──
+  server.tool(
+    "create_post",
+    "创建一篇新文章。需提供 title、slug、content（Markdown），可选 tags、category、status 等",
+    {
+      title: z.string().describe("文章标题"),
+      slug: z.string().describe("URL 标识符，如 my-first-post"),
+      content: z.string().describe("Markdown 格式的文章正文"),
+      excerpt: z.string().optional().describe("文章摘要"),
+      coverImage: z.string().optional().describe("封面图 URL"),
+      status: z.enum(["published", "draft", "scheduled"]).default("draft").describe("发布状态"),
+      tags: z.array(z.string()).default([]).describe("标签列表"),
+      category: z.string().optional().describe("分类名称"),
+      series: z.string().optional().describe("所属系列 slug"),
+      seriesOrder: z.number().optional().describe("系列中的排序"),
+      pinned: z.boolean().default(false).describe("是否置顶"),
+      allowComments: z.boolean().default(true).describe("是否允许评论"),
+      publishedAt: z.string().optional().describe("定时发布时间 (ISO 8601)"),
+    },
+    async (params) => {
+      const result = await apiRequest("/api/admin/posts", {
+        method: "POST",
+        body: params,
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 文章已创建：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 更新文章 ──
+  server.tool(
+    "update_post",
+    "更新指定 slug 的文章内容或元信息",
+    {
+      slug: z.string().describe("要更新的文章 slug"),
+      title: z.string().optional().describe("新标题"),
+      content: z.string().optional().describe("新的 Markdown 正文"),
+      excerpt: z.string().optional().describe("新摘要"),
+      coverImage: z.string().optional().describe("新封面图 URL"),
+      status: z.enum(["published", "draft", "scheduled"]).optional().describe("新状态"),
+      tags: z.array(z.string()).optional().describe("新标签列表"),
+      category: z.string().optional().describe("新分类"),
+      series: z.string().optional().describe("新系列 slug"),
+      seriesOrder: z.number().optional().describe("系列排序"),
+      pinned: z.boolean().optional().describe("是否置顶"),
+      allowComments: z.boolean().optional().describe("是否允许评论"),
+      publishedAt: z.string().optional().describe("定时发布时间"),
+    },
+    async ({ slug, ...updates }) => {
+      const result = await apiRequest(`/api/admin/posts/${slug}`, {
+        method: "PUT",
+        body: updates,
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 文章 "${slug}" 已更新：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 删除文章 ──
+  server.tool(
+    "delete_post",
+    "⚠️ 【高危操作】永久删除指定 slug 的文章，此操作不可逆！调用前请务必向主人确认。",
+    { slug: z.string().describe("要删除的文章 slug") },
+    async ({ slug }) => {
+      const result = await apiRequest(`/api/admin/posts/${slug}`, {
+        method: "DELETE",
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `🗑️ 文章 "${slug}" 已被永久删除。${JSON.stringify(result)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 批量操作文章 ──
+  server.tool(
+    "batch_posts",
+    "⚠️ 【高危操作】批量修改文章状态（发布/撤回/删除）。单次最多处理 10 篇。",
+    {
+      slugs: z.array(z.string()).max(10).describe("文章 slug 列表（最多 10 个）"),
+      action: z.enum(["publish", "draft", "delete"]).describe("批量动作"),
+    },
+    async ({ slugs, action }) => {
+      const result = await apiRequest("/api/admin/posts/batch", {
+        method: "POST",
+        body: { slugs, action },
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 批量 ${action} 完成（${slugs.length} 篇）：${JSON.stringify(result)}`,
+        }],
+      };
+    }
+  );
+
+  // ── 文章历史版本 ──
+  server.tool(
+    "list_post_versions",
+    "查看指定文章的历史修改版本列表",
+    { slug: z.string().describe("文章 slug") },
+    async ({ slug }) => {
+      const versions = await apiRequest(`/api/admin/posts/${slug}/versions`);
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(versions, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/tools/posts.ts
+++ b/mcp-server/src/tools/posts.ts
@@ -29,7 +29,7 @@ export function registerPostTools(server: McpServer) {
     "获取指定 slug 的文章完整内容（含 Markdown 正文、元信息）",
     { slug: z.string().describe("文章的 URL 标识符 (slug)") },
     async ({ slug }) => {
-      const post = await apiRequest(`/api/posts/${slug}`, { auth: false });
+      const post = await apiRequest(`/api/posts/${encodeURIComponent(slug)}`, { auth: false });
       return {
         content: [{
           type: "text" as const,
@@ -111,7 +111,7 @@ export function registerPostTools(server: McpServer) {
       publishedAt: z.string().optional().describe("定时发布时间"),
     },
     async ({ slug, ...updates }) => {
-      const result = await apiRequest(`/api/admin/posts/${slug}`, {
+      const result = await apiRequest(`/api/admin/posts/${encodeURIComponent(slug)}`, {
         method: "PUT",
         body: updates,
       });
@@ -128,9 +128,15 @@ export function registerPostTools(server: McpServer) {
   server.tool(
     "delete_post",
     "⚠️ 【高危操作】永久删除指定 slug 的文章，此操作不可逆！调用前请务必向主人确认。",
-    { slug: z.string().describe("要删除的文章 slug") },
-    async ({ slug }) => {
-      const result = await apiRequest(`/api/admin/posts/${slug}`, {
+    { 
+      slug: z.string().describe("要删除的文章 slug"),
+      confirm: z.enum(["yes"]).describe("必须输入 'yes' 确认高危操作")
+    },
+    async ({ slug, confirm }) => {
+      if (confirm !== "yes") {
+        return { content: [{ type: "text" as const, text: "❌ 操作已取消：未确认高危操作。" }], isError: true };
+      }
+      const result = await apiRequest(`/api/admin/posts/${encodeURIComponent(slug)}`, {
         method: "DELETE",
       });
       return {
@@ -149,8 +155,12 @@ export function registerPostTools(server: McpServer) {
     {
       slugs: z.array(z.string()).max(10).describe("文章 slug 列表（最多 10 个）"),
       action: z.enum(["publish", "draft", "delete"]).describe("批量动作"),
+      confirm: z.enum(["yes"]).describe("如果是 delete 动作，必须输入 'yes' 确认。其他动作可选。")
     },
-    async ({ slugs, action }) => {
+    async ({ slugs, action, confirm }) => {
+      if (action === "delete" && confirm !== "yes") {
+        return { content: [{ type: "text" as const, text: "❌ 操作已取消：批量删除必须确认高危操作。" }], isError: true };
+      }
       const result = await apiRequest("/api/admin/posts/batch", {
         method: "POST",
         body: { slugs, action },
@@ -170,7 +180,7 @@ export function registerPostTools(server: McpServer) {
     "查看指定文章的历史修改版本列表",
     { slug: z.string().describe("文章 slug") },
     async ({ slug }) => {
-      const versions = await apiRequest(`/api/admin/posts/${slug}/versions`);
+      const versions = await apiRequest(`/api/admin/posts/${encodeURIComponent(slug)}/versions`);
       return {
         content: [{
           type: "text" as const,

--- a/mcp-server/src/tools/settings.ts
+++ b/mcp-server/src/tools/settings.ts
@@ -30,7 +30,7 @@ export function registerSettingsTools(server: McpServer) {
     {
       site_name: z.string().optional().describe("站点名称"),
       site_description: z.string().optional().describe("站点描述"),
-      posts_per_page: z.number().optional().describe("每页文章数"),
+      posts_per_page: z.number().int().min(1).max(100).optional().describe("每页文章数"),
       comments_require_approval: z.boolean().optional().describe("评论是否需要审核"),
       custom_header: z.string().optional().describe("注入到 <head> 中的自定义 HTML/JS"),
       custom_footer: z.string().optional().describe("注入到页面底部的自定义 HTML/JS"),

--- a/mcp-server/src/tools/settings.ts
+++ b/mcp-server/src/tools/settings.ts
@@ -1,0 +1,51 @@
+/* ──────────────────────────────────────────────
+   站点设置工具 (Settings)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerSettingsTools(server: McpServer) {
+  // ── 获取设置 ──
+  server.tool(
+    "get_settings",
+    "获取博客站点的完整配置（站名、描述、每页文章数、评论审核策略、自定义代码注入等）",
+    {},
+    async () => {
+      const settings = await apiRequest("/api/admin/settings");
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(settings, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 更新设置 ──
+  server.tool(
+    "update_settings",
+    "更新博客站点配置。只需传入要修改的字段即可，未传入的字段保持不变。",
+    {
+      site_name: z.string().optional().describe("站点名称"),
+      site_description: z.string().optional().describe("站点描述"),
+      posts_per_page: z.number().optional().describe("每页文章数"),
+      comments_require_approval: z.boolean().optional().describe("评论是否需要审核"),
+      custom_header: z.string().optional().describe("注入到 <head> 中的自定义 HTML/JS"),
+      custom_footer: z.string().optional().describe("注入到页面底部的自定义 HTML/JS"),
+    },
+    async (params) => {
+      const result = await apiRequest("/api/admin/settings", {
+        method: "PUT",
+        body: params,
+      });
+      return {
+        content: [{
+          type: "text" as const,
+          text: `✅ 站点设置已更新：${JSON.stringify(result, null, 2)}`,
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/tools/taxonomy.ts
+++ b/mcp-server/src/tools/taxonomy.ts
@@ -1,0 +1,57 @@
+/* ──────────────────────────────────────────────
+   分类与标签工具 (Taxonomy)
+   ────────────────────────────────────────────── */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { apiRequest } from "../client.js";
+
+export function registerTaxonomyTools(server: McpServer) {
+  // ── 列出所有标签 ──
+  server.tool(
+    "list_tags",
+    "获取博客中所有已使用的标签及其文章数量",
+    {},
+    async () => {
+      const tags = await apiRequest("/api/tags", { auth: false });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(tags, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 列出所有分类 ──
+  server.tool(
+    "list_categories",
+    "获取博客中所有分类及其文章数量",
+    {},
+    async () => {
+      const categories = await apiRequest("/api/categories", { auth: false });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(categories, null, 2),
+        }],
+      };
+    }
+  );
+
+  // ── 获取系列合集详情 ──
+  server.tool(
+    "get_series",
+    "获取指定系列合集的详细信息和包含的文章列表",
+    { slug: z.string().describe("系列 slug") },
+    async ({ slug }) => {
+      const series = await apiRequest(`/api/series/${slug}`, { auth: false });
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify(series, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,0 +1,75 @@
+/* ──────────────────────────────────────────────
+   Monolith MCP 服务器 — 共享类型定义
+   ────────────────────────────────────────────── */
+
+/** 文章数据结构 */
+export interface Post {
+  slug: string;
+  title: string;
+  content: string;
+  excerpt?: string;
+  coverImage?: string;
+  status: "published" | "draft" | "scheduled";
+  tags: string[];
+  category?: string;
+  series?: string;
+  seriesOrder?: number;
+  pinned?: boolean;
+  allowComments?: boolean;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt?: string;
+  viewCount?: number;
+}
+
+/** 评论数据结构 */
+export interface Comment {
+  id: number;
+  postSlug: string;
+  author: string;
+  email?: string;
+  website?: string;
+  content: string;
+  approved: boolean;
+  parentId?: number;
+  createdAt: string;
+}
+
+/** 媒体文件数据结构 */
+export interface MediaFile {
+  key: string;
+  size: number;
+  uploaded: string;
+  url: string;
+}
+
+/** 站点设置 */
+export interface SiteSettings {
+  site_name?: string;
+  site_description?: string;
+  posts_per_page?: number;
+  comments_require_approval?: boolean;
+  custom_header?: string;
+  custom_footer?: string;
+  [key: string]: unknown;
+}
+
+/** 仪表盘统计 */
+export interface DashboardStats {
+  totalPosts: number;
+  totalViews: number;
+  totalComments: number;
+  recentPosts: Post[];
+}
+
+/** 独立页面 */
+export interface Page {
+  slug: string;
+  title: string;
+  content: string;
+  status: "published" | "draft";
+  showInNav?: boolean;
+  sortOrder?: number;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## 变更描述

### 1. 🏠 Monolith MCP 服务器

为博客打造的全权管理 MCP 服务器，共 30 个工具：

| 模块 | 工具数 | 功能 |
|------|--------|------|
| 📝 文章管理 | 8 | list/get/create/update/delete/batch/search/versions |
| 💬 评论管理 | 3 | list/approve/delete |
| 🖼️ 媒体管理 | 3 | list/upload/delete |
| 📊 统计分析 | 3 | dashboard_stats/analytics/traffic |
| ⚙️ 站点设置 | 2 | get/update |
| 📄 独立页面 | 4 | list/get/upsert/delete |
| 🏷️ 分类标签 | 3 | tags/categories/series |
| 💾 备份恢复 | 4 | export/backup_to_r2/list_r2/restore |

### 2. 🐛 修复 marked v15 Markdown 渲染兼容性问题

marked v15 传入 renderer 的参数结构发生了变化：`text` 字段变成了原始 Markdown 文本，`header`/`rows` 变成了 Token 数组。旧代码直接拼接导致渲染异常。

**修复的 3 个 renderer：**

| Renderer | 问题 | 修复 |
|----------|------|------|
| `table` | 表格内容渲染为 `[object Object]` | 改用 `this.parser.parseInline()` 递归解析 cell tokens |
| `heading` | 标题中 `**粗体**` `\`代码\`` 原样显示 | 箭头函数 → `function`，用 parseInline 生成 HTML |
| `link` | 链接文本中格式未渲染 | 同上 |

**根因**：`new marked.Renderer()` + 箭头函数的 `this` 不绑定 parser，无法调用 `this.parser.parseInline()`。改用 `function` 声明后 marked 在调用时自动绑定 parser 上下文。

## 变更类型
- [x] ✨ 新功能 (MCP 服务器)
- [x] 🐛 Bug 修复 (Markdown 渲染)

## 测试
- [x] TypeScript 编译零错误
- [x] Node.js 测试确认 `this.parser.parseInline()` 正确输出 HTML
- [x] 10 篇含表格和代码块的文章发布验证