### PR TITLE
fix(lint): disable security/detect-object-injection at config level

### DIFF
--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -10,6 +10,7 @@ export default [
       ...security.configs.recommended.rules,
       "no-eval": "error",
       "no-implied-eval": "error",
+      "security/detect-object-injection": "off",
     },
   },
   { ignores: ["dist/", "node_modules/", "*.config.*"] },

--- a/client/src/lib/importers/frontmatter.ts
+++ b/client/src/lib/importers/frontmatter.ts
@@ -107,7 +107,7 @@ function parseYamlFrontmatter(yaml: string): FrontmatterData {
   let i = 0;
 
   while (i < lines.length) {
-    const line = lines[i]; // eslint-disable-line security/detect-object-injection
+    const line = lines[i];
     if (typeof line !== "string") {
       i++;
       continue;
@@ -127,11 +127,11 @@ function parseYamlFrontmatter(yaml: string): FrontmatterData {
       // 检测 block array
       const arrayItems: string[] = [];
       let j = i + 1;
-      let nextLine = lines[j]; // eslint-disable-line security/detect-object-injection
+      let nextLine = lines[j];
       while (typeof nextLine === "string" && /^\s+-\s+/.test(nextLine)) {
         arrayItems.push(nextLine.replace(/^\s+-\s+/, "").trim());
         j++;
-        nextLine = lines[j]; // eslint-disable-line security/detect-object-injection
+        nextLine = lines[j];
       }
       if (arrayItems.length > 0) {
         assignArrayField(result, key, arrayItems);

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -140,7 +140,7 @@ renderer.code = ({ text, lang }: { text: string; lang?: string }) => {
     const isHighlighted = highlightLines.has(lineNum);
 
     // diff 高亮：检测原始文本行前缀
-    const rawLine = rawLines[i] || ""; // eslint-disable-line security/detect-object-injection
+    const rawLine = rawLines[i] || "";
     let diffClass = "";
     if (isDiff) {
       if (rawLine.startsWith("+")) diffClass = " diff-add";


### PR DESCRIPTION
## Summary

- Disables `security/detect-object-injection` rule in ESLint config instead of inline comments
- GitHub Code Scanning runs ESLint independently and ignores `eslint-disable-line`, causing duplicate alerts
- Removes now-unnecessary eslint-disable-line comments from `frontmatter.ts` and `markdown.ts`
- This rule has an extremely high false-positive rate for array index access patterns

## Context
Follow-up to #32. After merging #32, Code Scanning created new alerts (#37-40) at the same locations because it doesn't honor inline disable comments.