### PR TITLE
fix(security): harden Monolith against XSS, SSRF, info leaks, and abuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ dist/
 # 环境变量
 .env
 .env.local
+.env.*
+!.env.example
 .dev.vars
 
 # 系统文件

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,99 @@
+# 隐私政策 / Privacy Policy
+
+最后更新 / Last updated: 2026-04-19
+
+---
+
+## 数据收集声明
+
+Monolith 博客在您访问时可能自动收集以下非个人身份信息：
+
+| 数据类型 | 来源 | 用途 | 存储方式 |
+|---------|------|------|---------|
+| 访问页面路径 | 请求 URL | 内容统计 | 边缘数据库 |
+| 访客来源国家 | Cloudflare `CF-IPCountry` 头 | 流量分析 | 边缘数据库 |
+| 来源域名 | `Referer` 头 | 流量分析 | 边缘数据库 |
+| 设备类型 | `User-Agent` 解析（仅区分 desktop/mobile/bot） | 响应式优化 | 边缘数据库 |
+| 评论者昵称 | 用户主动填写 | 公开展示 | 边缘数据库 |
+
+**我们不收集：** IP 地址（仅处理为不可逆哈希用于投票去重）、邮箱地址不在公开 API 中返回。
+
+## Cookie 使用
+
+| Cookie | 用途 | 持续时间 |
+|--------|------|---------|
+| 认证 Token | 管理员登录 | 7 天 |
+| `_gdpr_consent` | 记录隐私同意 | 1 年 |
+
+站点管理员可通过"扩展与注入"设置添加第三方分析脚本（如 Google Analytics）。此类脚本可能设置额外的 Cookie，需遵守本政策的同意机制。
+
+## 第三方脚本同意机制
+
+当站点配置了自定义头部/尾部脚本（如分析服务），访客将看到 Cookie 同意横幅。**在您明确同意之前，第三方脚本不会被加载。** 您可以随时撤回同意。
+
+## 数据存储与处理
+
+- 所有数据存储在 Cloudflare 边缘网络（Workers + D1/R2），位于就近的数据中心
+- 评论者邮箱仅用于管理员审核通知，不会在他的评论旁公开显示
+- 我们不售卖、共享或传输用户数据给第三方
+
+## 数据删除请求
+
+如您希望删除您的评论或相关数据，请通过以下方式联系：
+
+- GitHub Issue（公开请求）
+- [GitHub Security Advisories](https://github.com/one-ea/Monolith/security/advisories/new)（私密请求）
+
+我们将在 14 个工作日内处理您的请求。
+
+## 政策更新
+
+本隐私政策可能不定期更新，重大变更将在博客页面上公告。继续访问本站即表示您同意本政策。
+
+---
+
+## Data Collection Notice
+
+Monolith blog may automatically collect the following non-personally identifiable information when you visit:
+
+| Data Type | Source | Purpose | Storage |
+|-----------|--------|---------|---------|
+| Page path visited | Request URL | Content analytics | Edge database |
+| Visitor country | Cloudflare `CF-IPCountry` header | Traffic analysis | Edge database |
+| Referrer domain | `Referer` header | Traffic analysis | Edge database |
+| Device type | `User-Agent` parsing (desktop/mobile/bot only) | Responsive optimization | Edge database |
+| Commenter nickname | User-provided | Public display | Edge database |
+
+**We do not collect:** IP addresses (only hashed for vote deduplication), email addresses are never returned in public APIs.
+
+## Cookie Usage
+
+| Cookie | Purpose | Duration |
+|--------|---------|----------|
+| Auth Token | Admin login | 7 days |
+| `_gdpr_consent` | Records privacy consent | 1 year |
+
+Site administrators may add third-party analytics scripts via "Extensions & Injection" settings. Such scripts may set additional cookies and are subject to the consent mechanism described in this policy.
+
+## Third-Party Script Consent
+
+When custom header/footer scripts (e.g., analytics) are configured, visitors will see a cookie consent banner. **Third-party scripts are not loaded until you explicitly consent.** You may withdraw consent at any time.
+
+## Data Storage & Processing
+
+- All data is stored on the Cloudflare edge network (Workers + D1/R2) in nearest data centers
+- Commenter emails are used only for admin review notifications and are never displayed publicly
+- We do not sell, share, or transfer user data to third parties
+
+## Data Deletion Requests
+
+To request deletion of your comments or related data, please contact us via:
+
+- GitHub Issue (public request)
+- [GitHub Security Advisories](https://github.com/one-ea/Monolith/security/advisories/new) (private request)
+
+We will process your request within 14 business days.
+
+## Policy Updates
+
+This privacy policy may be updated periodically. Major changes will be announced on the blog. Continued use of this site constitutes acceptance of this policy.

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,1 +1,0 @@
-VITE_API_URL=https://monolith-server.h005-9d9.workers.dev

--- a/client/functions/api/[[path]].ts
+++ b/client/functions/api/[[path]].ts
@@ -8,21 +8,25 @@ import {
 export const onRequest: PagesFunction<{ API_BASE: string }> = async (context) => {
   // 直接处理 CORS 预检请求，不转发
   if (context.request.method === "OPTIONS") {
+    const origin = context.request.headers.get("Origin") || "*";
     return new Response(null, {
       status: 204,
       headers: {
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": origin,
         "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
         "Access-Control-Allow-Headers": "Content-Type, Authorization",
         "Access-Control-Max-Age": "86400",
+        "Vary": "Origin",
       },
     });
   }
 
   const backend = getBackendUrl(context.env);
   if (!backend) {
+    const origin = context.request.headers.get("Origin") || "*";
     return createApiBaseErrorResponse({
-      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Origin": origin,
+      "Vary": "Origin",
     });
   }
 
@@ -37,8 +41,10 @@ export const onRequest: PagesFunction<{ API_BASE: string }> = async (context) =>
     redirect: "manual", // 不跟随重定向，原样返回 30x
   });
 
+  const origin = context.request.headers.get("Origin") || "*";
   const responseHeaders = new Headers(res.headers);
-  responseHeaders.set("Access-Control-Allow-Origin", "*");
+  responseHeaders.set("Access-Control-Allow-Origin", origin);
+  responseHeaders.set("Vary", "Origin");
 
   return new Response(res.body, {
     status: res.status,

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/footer";
 import { SearchOverlay } from "@/components/search";
 import { ProtectedRoute } from "@/components/protected-route";
 import { AdminLayout } from "@/components/admin-layout";
+import { CookieConsent, getCookieConsent } from "@/components/cookie-consent";
 
 // 代码分割 (Code Splitting)
 const HomePage = lazy(() => import("@/pages/home").then((m) => ({ default: m.HomePage })));
@@ -21,6 +22,7 @@ const AdminPages = lazy(() => import("@/pages/admin/pages").then((m) => ({ defau
 const AdminComments = lazy(() => import("@/pages/admin/comments").then((m) => ({ default: m.AdminComments })));
 const AdminMedia = lazy(() => import("@/pages/admin/media").then((m) => ({ default: m.AdminMedia })));
 const AdminAnalytics = lazy(() => import("@/pages/admin/analytics").then((m) => ({ default: m.AdminAnalytics })));
+const PrivacyPage = lazy(() => import("@/pages/privacy").then((m) => ({ default: m.PrivacyPage })));
 const DynamicPage = lazy(() => import("@/pages/dynamic-page").then((m) => ({ default: m.DynamicPage })));
 const NotFoundPage = lazy(() => import("@/pages/not-found").then((m) => ({ default: m.NotFoundPage })));
 
@@ -62,23 +64,36 @@ export function App() {
   const isAdminArea = isAdminRoot && !isEditorPage && !isLoginPage;
   const isPublicPage = !isAdminRoot;
 
-  // 注入自定义 header/footer 代码（仅执行一次）
+  // 注入自定义 header/footer 代码（需 Cookie 同意后加载第三方脚本）
   useEffect(() => {
     fetch("/api/settings/public")
       .then((r) => r.json())
       .then((s) => {
-        if (s.custom_header) {
-          const container = document.createElement("div");
-          container.id = "monolith-custom-header";
-          injectHtml(container, s.custom_header);
-          // 将子节点移入 head
-          Array.from(container.childNodes).forEach((n) => document.head.appendChild(n));
-        }
-        if (s.custom_footer) {
-          const container = document.createElement("div");
-          container.id = "monolith-custom-footer";
-          injectHtml(container, s.custom_footer);
-          document.body.appendChild(container);
+        const hasThirdParty = (s.custom_header && /<script/i.test(s.custom_header))
+          || (s.custom_footer && /<script/i.test(s.custom_footer));
+
+        const inject = () => {
+          if (s.custom_header) {
+            const container = document.createElement("div");
+            container.id = "monolith-custom-header";
+            injectHtml(container, s.custom_header);
+            Array.from(container.childNodes).forEach((n) => document.head.appendChild(n));
+          }
+          if (s.custom_footer) {
+            const container = document.createElement("div");
+            container.id = "monolith-custom-footer";
+            injectHtml(container, s.custom_footer);
+            document.body.appendChild(container);
+          }
+        };
+
+        // 无第三方脚本则直接注入；有则等 Cookie 同意
+        if (!hasThirdParty) {
+          inject();
+        } else if (getCookieConsent()) {
+          inject();
+        } else {
+          window.addEventListener("cookie-consent-accepted", inject, { once: true });
         }
       })
       .catch(() => {});
@@ -99,6 +114,7 @@ export function App() {
                 <Route path="/posts/:slug" component={PostPage} />
                 <Route path="/archive" component={ArchivePage} />
                 <Route path="/about" component={AboutPage} />
+                <Route path="/privacy" component={PrivacyPage} />
                 <Route path="/page/:slug" component={DynamicPage} />
                 <Route>
                   <NotFoundPage />
@@ -107,6 +123,7 @@ export function App() {
             </Suspense>
           </main>
           <Footer />
+          <CookieConsent />
         </>
       )}
 

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,5 +1,6 @@
 import { Route, Switch, useLocation } from "wouter";
 import { useEffect, Suspense, lazy } from "react";
+import DOMPurify from "dompurify";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { SearchOverlay } from "@/components/search";
@@ -24,17 +25,22 @@ const DynamicPage = lazy(() => import("@/pages/dynamic-page").then((m) => ({ def
 const NotFoundPage = lazy(() => import("@/pages/not-found").then((m) => ({ default: m.NotFoundPage })));
 
 
-/** 将 HTML 字符串安全注入到容器中（支持 script 标签执行） */
+/** 将设置中的 HTML/JS 代码安全注入到页面（仅允许外部脚本 src） */
 function injectHtml(container: HTMLElement, html: string) {
   const temp = document.createElement("div");
-  temp.innerHTML = html;
+  temp.innerHTML = DOMPurify.sanitize(html, {
+    ADD_TAGS: ["script"],
+    ADD_ATTR: ["src", "async", "defer"],
+    FORBID_TAGS: ["style", "iframe", "object", "embed", "form"],
+    FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
+  });
   Array.from(temp.childNodes).forEach((node) => {
     if (node instanceof HTMLScriptElement) {
-      // script 需要重新创建才能执行
+      if (!node.src) return; // 禁止内联脚本，只允许带 src 的外部脚本
       const script = document.createElement("script");
-      if (node.src) script.src = node.src;
-      else script.textContent = node.textContent;
-      Array.from(node.attributes).forEach((a) => script.setAttribute(a.name, a.value));
+      script.src = node.src;
+      if (node.hasAttribute("async")) script.async = true;
+      if (node.hasAttribute("defer")) script.defer = true;
       container.appendChild(script);
     } else {
       container.appendChild(node.cloneNode(true));

--- a/client/src/components/comments.tsx
+++ b/client/src/components/comments.tsx
@@ -10,22 +10,10 @@ function formatDate(dateStr: string): string {
   });
 }
 
-/** 通过邮箱生成 Gravatar 头像 URL */
-function gravatarUrl(email: string, size = 40): string {
-  // 简单 hash 用于无邮箱时的默认颜色
-  if (!email) return `https://api.dicebear.com/7.x/initials/svg?seed=U&size=${size}`;
-  const trimmed = email.trim().toLowerCase();
-  return `https://gravatar.com/avatar/${simpleHash(trimmed)}?s=${size}&d=identicon`;
-}
-
-function simpleHash(str: string): string {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash |= 0;
-  }
-  return Math.abs(hash).toString(16).padStart(32, "0");
+/** 通过昵称生成 DiceBear 头像 URL（不再传输邮箱） */
+function avatarUrl(name: string, size = 40): string {
+  const seed = encodeURIComponent(name.trim() || "U");
+  return `https://api.dicebear.com/7.x/initials/svg?seed=${seed}&size=${size}`;
 }
 
 /* ── 单条评论 ──────────────────────────── */
@@ -34,7 +22,7 @@ function CommentItem({ comment }: { comment: CommentData }) {
     <div className="group flex gap-[12px] py-[16px]">
       <div className="shrink-0">
         <img
-          src={gravatarUrl(comment.authorEmail)}
+          src={avatarUrl(comment.authorName)}
           alt={comment.authorName}
           className="h-[36px] w-[36px] rounded-full bg-card/30 ring-1 ring-border/20"
           loading="lazy"

--- a/client/src/components/cookie-consent.tsx
+++ b/client/src/components/cookie-consent.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+const CONSENT_KEY = "_gdpr_consent";
+const CONSENT_EXPIRY_DAYS = 365;
+
+function getConsent(): "accepted" | "rejected" | null {
+  try {
+    const raw = localStorage.getItem(CONSENT_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (Date.now() > data.expires) {
+      localStorage.removeItem(CONSENT_KEY);
+      return null;
+    }
+    return data.value as "accepted" | "rejected";
+  } catch {
+    return null;
+  }
+}
+
+function setConsent(value: "accepted" | "rejected") {
+  localStorage.setItem(CONSENT_KEY, JSON.stringify({
+    value,
+    expires: Date.now() + CONSENT_EXPIRY_DAYS * 86400000,
+  }));
+}
+
+export function getCookieConsent(): boolean {
+  return getConsent() === "accepted";
+}
+
+export function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(getConsent() === null);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-[9999] p-[12px] animate-fade-in">
+      <div className="mx-auto max-w-[720px] rounded-xl border border-border/30 bg-card/95 backdrop-blur-md shadow-lg shadow-black/20 px-[20px] py-[16px] flex flex-col sm:flex-row items-start sm:items-center gap-[12px]">
+        <div className="flex-1 text-[13px] text-muted-foreground/80 leading-[1.6]">
+          本站使用 Cookie 进行访问统计与第三方脚本加载。继续访问即表示您同意我们的{" "}
+          <a href="/privacy" className="text-foreground/70 underline underline-offset-2 hover:text-foreground transition-colors">隐私政策</a>。
+        </div>
+        <div className="flex gap-[8px] shrink-0">
+          <button
+            onClick={() => { setConsent("rejected"); setVisible(false); }}
+            className="px-[14px] py-[6px] text-[12px] rounded-md border border-border/30 text-muted-foreground/60 hover:text-foreground hover:border-border/50 transition-all"
+          >
+            拒绝
+          </button>
+          <button
+            onClick={() => { setConsent("accepted"); window.dispatchEvent(new Event("cookie-consent-accepted")); setVisible(false); }}
+            className="px-[14px] py-[6px] text-[12px] rounded-md bg-foreground text-background font-medium hover:bg-foreground/80 transition-all"
+          >
+            接受
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -290,13 +290,13 @@ export type CommentData = {
   id: number;
   postId: number;
   authorName: string;
-  authorEmail: string;
   content: string;
   approved: boolean;
   createdAt: string;
 };
 
 export type AdminComment = CommentData & {
+  authorEmail: string;
   postSlug: string;
   postTitle: string;
 };

--- a/client/src/lib/markdown.ts
+++ b/client/src/lib/markdown.ts
@@ -279,8 +279,9 @@ renderer.table = function (token: any) {
 // 链接：外部链接自动 target="_blank"（兼容 marked v15 token 结构）
 renderer.link = function (token: any) {
   const href = token.href || '';
+  // 防止 javascript: URI XSS
+  if (/^\s*javascript:/i.test(href)) return escapeHtml(token.text || href);
   const title = token.title || '';
-  // 用 parseInline 解析链接文本中的 inline 格式
   const text = token.tokens && this.parser
     ? this.parser.parseInline(token.tokens)
     : (token.text || '');

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -299,6 +299,9 @@ export function AdminSettings() {
                   危险操作区 <span className="text-[10px] px-[6px] py-[2px] rounded-md bg-amber-500/10 text-amber-500 border border-amber-500/20 font-mono">Expert</span>
                 </h2>
                 <p className="text-[12px] text-muted-foreground/50 mb-[16px]">向站点核心区域注入自定义脚本或标签。错误的语法可能导致前端崩溃。</p>
+                <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-[12px] py-[8px] mb-[16px] text-[11px] text-amber-400/80">
+                  ⚠️ 隐私提醒：注入的分析脚本（如 Google Analytics）会在访客浏览器中执行。根据 GDPR 等隐私法规，您需确保已获得访客明示同意。Monolith 内置 Cookie 同意横幅，访客接受后才会加载第三方脚本。
+                </div>
                 <div className="rounded-xl border border-border/15 bg-card/5 p-[20px] sm:p-[24px] space-y-[20px]">
                   <div>
                     <label className="mb-[6px] block text-[11px] font-bold text-amber-500/70 uppercase tracking-wider">&lt;head&gt; 注入区域</label>

--- a/client/src/pages/privacy.tsx
+++ b/client/src/pages/privacy.tsx
@@ -1,0 +1,121 @@
+import { SeoHead } from "@/components/seo-head";
+
+export function PrivacyPage() {
+  return (
+    <div className="mx-auto w-full max-w-[720px] py-[32px] lg:py-[56px] px-[16px] lg:px-0">
+      <SeoHead
+        title="隐私政策"
+        description="Monolith 博客的数据收集与隐私保护政策。"
+        url="/privacy"
+      />
+      <h1 className="text-[28px] font-semibold tracking-[-0.02em]">隐私政策</h1>
+      <p className="text-[13px] text-muted-foreground/40 mt-[4px] mb-[24px]">
+        最后更新：2025-04-19 · Last updated: 2026-04-19
+      </p>
+      <div className="prose-monolith space-y-[24px]">
+        <section>
+          <h2>数据收集声明</h2>
+          <p>Monolith 博客在您访问时可能自动收集以下非个人身份信息：</p>
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="border-b border-border/20">
+                <th className="text-left py-[8px] pr-[12px]">数据类型</th>
+                <th className="text-left py-[8px] pr-[12px]">来源</th>
+                <th className="text-left py-[8px]">用途</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-border/10">
+                <td className="py-[8px] pr-[12px]">访问页面路径</td>
+                <td className="py-[8px] pr-[12px]">请求 URL</td>
+                <td className="py-[8px]">内容统计</td>
+              </tr>
+              <tr className="border-b border-border/10">
+                <td className="py-[8px] pr-[12px]">访客来源国家</td>
+                <td className="py-[8px] pr-[12px]">Cloudflare 头</td>
+                <td className="py-[8px]">流量分析</td>
+              </tr>
+              <tr className="border-b border-border/10">
+                <td className="py-[8px] pr-[12px]">来源域名</td>
+                <td className="py-[8px] pr-[12px]">Referer 头</td>
+                <td className="py-[8px]">流量分析</td>
+              </tr>
+              <tr className="border-b border-border/10">
+                <td className="py-[8px] pr-[12px]">设备类型</td>
+                <td className="py-[8px] pr-[12px]">User-Agent</td>
+                <td className="py-[8px]">响应式优化</td>
+              </tr>
+              <tr>
+                <td className="py-[8px] pr-[12px]">评论者昵称</td>
+                <td className="py-[8px] pr-[12px]">用户主动填写</td>
+                <td className="py-[8px]">公开展示</td>
+              </tr>
+            </tbody>
+          </table>
+          <p className="text-[13px] text-muted-foreground/60 mt-[8px]">
+            我们不收集 IP 地址原始值（仅做不可逆哈希用于投票去重），邮箱地址不会在公开 API 中返回。
+          </p>
+        </section>
+
+        <section>
+          <h2>Cookie 使用</h2>
+          <table className="w-full text-[13px]">
+            <thead>
+              <tr className="border-b border-border/20">
+                <th className="text-left py-[8px] pr-[12px]">Cookie</th>
+                <th className="text-left py-[8px] pr-[12px]">用途</th>
+                <th className="text-left py-[8px]">持续时间</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-border/10">
+                <td className="py-[8px] pr-[12px]">认证 Token</td>
+                <td className="py-[8px] pr-[12px]">管理员登录</td>
+                <td className="py-[8px]">7 天</td>
+              </tr>
+              <tr>
+                <td className="py-[8px] pr-[12px]">_gdpr_consent</td>
+                <td className="py-[8px] pr-[12px]">记录隐私同意</td>
+                <td className="py-[8px]">1 年</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <h2>第三方脚本同意机制</h2>
+          <p>
+            当站点配置了第三方脚本（如 Google Analytics）时，访客将看到 Cookie 同意横幅。
+            在您明确同意之前，第三方脚本<strong>不会</strong>被加载。您可以随时撤回同意。
+          </p>
+        </section>
+
+        <section>
+          <h2>数据存储与处理</h2>
+          <ul>
+            <li>所有数据存储在 Cloudflare 边缘网络（Workers + D1/R2），位于就近的数据中心</li>
+            <li>评论者邮箱仅用于管理员审核通知，不会在评论旁公开显示</li>
+            <li>我们不出售、共享或传输用户数据给第三方</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>数据删除请求</h2>
+          <p>
+            如您希望删除您的评论或相关数据，请通过以下方式联系：
+          </p>
+          <ul>
+            <li><a href="https://github.com/one-ea/Monolith/issues" className="text-foreground/70 underline hover:text-foreground transition-colors">GitHub Issue</a>（公开请求）</li>
+            <li><a href="https://github.com/one-ea/Monolith/security/advisories/new" className="text-foreground/70 underline hover:text-foreground transition-colors">GitHub Security Advisories</a>（私密请求）</li>
+          </ul>
+          <p className="text-[13px] text-muted-foreground/60">我们将在 14 个工作日内处理您的请求。</p>
+        </section>
+
+        <section>
+          <h2>政策更新</h2>
+          <p>本隐私政策可能不定期更新，重大变更将在博客页面上公告。继续访问本站即表示您同意本政策。</p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -70,5 +70,6 @@ export default defineConfig({
   },
   build: {
     outDir: "dist",
+    sourcemap: false,
   },
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,7 @@ type Bindings = {
   BUCKET: R2Bucket;
   ADMIN_PASSWORD: string;
   JWT_SECRET: string;
+  REACTION_SALT?: string;
   DB_PROVIDER?: string;
   STORAGE_PROVIDER?: string;
   WEBHOOK_URLS?: string; // 逗号分隔的 Webhook 目标地址
@@ -33,10 +34,22 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 /* ── 全局中间件 ────────────────────────────── */
 app.use("*", cors({
-  origin: "*",
+  origin: (origin) => origin || "*",
   allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
   allowHeaders: ["Content-Type", "Authorization"],
 }));
+
+app.use("*", async (c, next) => {
+  await next();
+  const headers = c.res.headers;
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  if (c.req.url.startsWith("https://")) {
+    headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  }
+});
 
 // 注入存储实例到上下文（每次请求创建 — 在边缘环境中是无状态的）
 app.use("*", async (c, next) => {
@@ -81,13 +94,7 @@ async function triggerWebhook(c: any, eventName: string, payload: any) {
 
 /* ── 健康检查端点 ──────────────────────────── */
 app.get("/api/health", async (c) => {
-  return c.json({
-    status: "ok",
-    timestamp: new Date().toISOString(),
-    dbProvider: c.env.DB_PROVIDER || "d1",
-    storageProvider: c.env.STORAGE_PROVIDER || "r2",
-    environment: "production"
-  });
+  return c.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 /* ── 公开 API ──────────────────────────────── */
 
@@ -174,12 +181,13 @@ app.get("/api/categories", async (c) => {
   return c.json(categories);
 });
 
-// 获取文章评论（仅已审核）
+// 获取文章评论（仅已审核，不暴露邮箱）
 app.get("/api/posts/:slug/comments", async (c) => {
   const slug = c.req.param("slug");
   const db = c.get("db");
   const comments = await db.getApprovedComments(slug);
-  return c.json(comments);
+  const safe = comments.map(({ author_email, authorEmail, ...rest }: any) => rest);
+  return c.json(safe);
 });
 
 // 提交评论（公开接口，需审核后才显示）
@@ -262,10 +270,11 @@ app.post("/api/posts/:slug/reactions", async (c) => {
     return c.json({ error: "无效的反应类型" }, 400);
   }
 
-  // IP hash 去重
+  // IP hash 去重（使用环境变量盐值，避免源码泄露后可反推）
   const ip = c.req.header("CF-Connecting-IP") || c.req.header("X-Forwarded-For") || "unknown";
+  const reactionSalt = c.env.REACTION_SALT || "monolith-reaction-default";
   const encoder = new TextEncoder();
-  const data = encoder.encode(ip + ":monolith-reaction-salt");
+  const data = encoder.encode(ip + ":" + reactionSalt);
   const hashBuffer = await crypto.subtle.digest("SHA-256", data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const ipHash = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
@@ -429,19 +438,41 @@ Sitemap: ${siteUrl}/sitemap.xml
   });
 });
 
+/* ── 登录速率限制 ─────────────────────────── */
+const loginAttempts = new Map<string, { count: number; firstAttempt: number }>();
+const LOGIN_RATE_LIMIT = 5;       // 最多 5 次
+const LOGIN_RATE_WINDOW = 15 * 60 * 1000; // 15 分钟窗口
+
 /* ── 认证 API ──────────────────────────────── */
 
 // 登录
 app.post("/api/auth/login", async (c) => {
+  const ip = c.req.header("CF-Connecting-IP") || c.req.header("X-Forwarded-For") || "unknown";
+
+  // 速率限制
+  const now = Date.now();
+  const record = loginAttempts.get(ip);
+  if (record && record.count >= LOGIN_RATE_LIMIT && (now - record.firstAttempt) < LOGIN_RATE_WINDOW) {
+    return c.json({ error: "尝试次数过多，请稍后再试" }, 429);
+  }
+  if (!record || (now - record.firstAttempt) >= LOGIN_RATE_WINDOW) {
+    loginAttempts.set(ip, { count: 1, firstAttempt: now });
+  } else {
+    record.count++;
+  }
+
   const body = await c.req.json<{ password: string }>();
 
   if (!body.password || body.password !== c.env.ADMIN_PASSWORD) {
     return c.json({ error: "密码错误" }, 401);
   }
 
-  const now = Math.floor(Date.now() / 1000);
+  // 登录成功后清除速率限制
+  loginAttempts.delete(ip);
+
+  const now2 = Math.floor(Date.now() / 1000);
   const token = await sign(
-    { sub: "admin", iat: now, exp: now + 60 * 60 * 24 * 7 },
+    { sub: "admin", iat: now2, exp: now2 + 60 * 60 * 24 * 7 },
     c.env.JWT_SECRET,
     "HS256"
   );
@@ -609,24 +640,34 @@ app.delete("/api/admin/posts/:slug", async (c) => {
 /** 从 Markdown 内容中提取所有外链图片 URL */
 function extractExternalImageUrls(content: string): string[] {
   const urls = new Set<string>();
-  // Markdown 格式：![alt](url) 或 ![alt](url "title")
   const mdRegex = /!\[[^\]]*\]\(([^\s"')]+)/g;
   let match;
   while ((match = mdRegex.exec(content)) !== null) {
     const url = match[1].trim();
     if (url && !url.startsWith("/") && !url.startsWith("data:")) {
-      try { new URL(url); urls.add(url); } catch { /* 非合法 URL 跳过 */ }
+      try { new URL(url); urls.add(url); } catch { /* non-URL skip */ }
     }
   }
-  // HTML img 标签：<img src="url">
   const imgRegex = /<img[^>]+src=["']([^"']+)["']/gi;
   while ((match = imgRegex.exec(content)) !== null) {
     const url = match[1].trim();
     if (url && !url.startsWith("/") && !url.startsWith("data:")) {
-      try { new URL(url); urls.add(url); } catch { /* 跳过 */ }
+      try { new URL(url); urls.add(url); } catch { /* skip */ }
     }
   }
   return Array.from(urls);
+}
+
+/** SSRF 防护：仅允许 https:// 开头的外部图片地址 */
+function isSafeImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    if (/^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.|0\.|169\.254\.)/.test(parsed.hostname)) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // 单篇文章：外链图片转本地
@@ -649,6 +690,11 @@ app.post("/api/admin/posts/:slug/localize-images", async (c) => {
   let content = post.content;
 
   for (const url of externalUrls) {
+    if (!isSafeImageUrl(url)) {
+      failed++;
+      errors.push(`${url}: 仅允许 HTTPS 外部图片地址`);
+      continue;
+    }
     try {
       const abortCtrl = new AbortController();
       const timeoutId = setTimeout(() => abortCtrl.abort(), 10000); // 10秒超时
@@ -714,6 +760,7 @@ app.post("/api/admin/localize-all-images", async (c) => {
     let content = post.content;
 
     for (const url of externalUrls) {
+      if (!isSafeImageUrl(url)) { failed++; continue; }
       try {
         const resp = await fetch(url, { headers: { "User-Agent": "Monolith-Bot/1.0" } });
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
@@ -993,6 +1040,19 @@ app.post("/api/admin/backup/webdav", async (c) => {
     url: string; username: string; password: string; path?: string;
   }>();
 
+  // SSRF 防护：仅允许 https:// 的外部 URL
+  try {
+    const parsed = new URL(body.url);
+    if (parsed.protocol !== "https:") {
+      return c.json({ error: "仅允许 HTTPS 协议的 WebDAV 地址" }, 400);
+    }
+    if (/^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.|0\.|169\.254\.|::1|fc)/.test(parsed.hostname)) {
+      return c.json({ error: "不允许内网地址" }, 400);
+    }
+  } catch {
+    return c.json({ error: "无效的 WebDAV 地址" }, 400);
+  }
+
   const db = c.get("db");
   const data = await db.exportAll();
   const json = JSON.stringify(data, null, 2);
@@ -1207,11 +1267,7 @@ app.post("/api/admin/pages/delete", async (c) => {
   return c.json({ success: true });
 });
 
-/* ── 健康检查 ──────────────────────────────── */
-app.get("/api/health", (c) => {
-  return c.json({ status: "ok", timestamp: new Date().toISOString() });
-});
-
+/* ── Durable Object / 导出 ──────────────────── */
 export default {
   fetch: app.fetch,
   async scheduled(event: any, env: Bindings, ctx: any) {


### PR DESCRIPTION
## Summary

Critical/High severity fixes:

1. **Stored XSS via `injectHtml()`** — Sanitize custom_header/footer through DOMPurify, forbid inline scripts, only allow external `<script src>` (fixes #1)
2. **Missing security headers** — Add X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, HSTS (fixes #5)
3. **Comment email exposure** — Remove `authorEmail` from public `/api/posts/:slug/comments` response, use DiceBear avatar by nickname instead of Gravatar hash (fixes #2, #14)
4. **Login brute force** — Add rate limiting: 5 attempts per 15 min per IP (fixes #3)
5. **CORS wildcard** — Reflect request `Origin` header instead of `*` in both Workers and Pages Function (fixes #4)
6. **SSRF via WebDAV & image localization** — Only allow `https://` URLs, block private/internal IP ranges (fixes #6, #13)
7. **Markdown XSS via `javascript:` URI** — Filter `javascript:` scheme in link renderer (fixes #7)

Medium severity fixes:

8. **Hardcoded hash salt** — Replace with `REACTION_SALT` env var (fixes #9)
9. **`.env.production` in git** — Add `.env.*` to `.gitignore`, remove from tracking (fixes #10)
10. **Production source maps** — Disable with `sourcemap: false` (fixes #11)
11. **Health endpoint info leak** — Remove dbProvider/storageProvider/environment (fixes #15)

## Test
- [x] `npm run build` passes
- [x] `tsc --noEmit` passes (both client & server)