### PR TITLE
fix(ci): use PAT_TOKEN for dependabot auto-approve

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.PAT_TOKEN}}
 
       - name: Enable Auto-Merge (Squash) for minor/patch
         if: steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'


### PR DESCRIPTION
Dependabot auto-merge workflow was failing because `GITHUB_TOKEN` cannot self-approve PRs. Switched to `PAT_TOKEN` secret for the approve step.