### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-client",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,26 @@
 {
   "name": "monolith",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monolith",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "workspaces": [
         "client",
         "server"
       ],
       "devDependencies": {
         "concurrently": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "client": {
       "name": "monolith-client",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@monaco-editor/react": "^4.7.0",
@@ -14821,7 +14824,7 @@
     },
     "server": {
       "name": "monolith-server",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1024.0",
         "@libsql/client": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": true,
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-server",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v2.0.0 — V1 周期收口，进入 V2 主线

把根 / client / server 三个 workspace 的 `version` 从 `0.1.0` 一步抬到 `2.0.0`，标记 V1（边缘博客 MVP + 双主题 + 三适配器存储 + 部署铁律 + 安全加固）整体收尾。

### 包含的近期主线变更
- #45 chore: refresh repo metadata + fix CI (setup-node v6→v4)
- #46 chore(repo): add lint scripts, .nvmrc, .editorconfig, CONTRIBUTING.md
- 历次 dependabot 安全升级（fast-xml-parser、@aws-sdk/xml-builder 等）

### 改动文件
- `package.json` `0.1.0 → 2.0.0`
- `client/package.json` `0.1.0 → 2.0.0`
- `server/package.json` `0.1.0 → 2.0.0`
- `package-lock.json` 同步

### 合并后动作
1. 创建 GitHub Release `v2.0.0`（generate-notes）
2. `npm run deploy:cloudflare` 一键发布到生产（远程迁移 + Workers + Pages）
