### PR TITLE
feat(seo): SEO 仪表盘 + sitemap/robots 路由代理与 origin 修正

### DIFF
--- a/client/functions/robots.txt.ts
+++ b/client/functions/robots.txt.ts
@@ -5,16 +5,26 @@ import {
 } from "./_shared";
 
 // 代理 /robots.txt 到 Workers 后端
+// 仅允许 GET/HEAD，避免成为开放 method 转发器
 export const onRequest: PagesFunction<{ API_BASE: string }> = async (context) => {
+  const method = context.request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD", "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
   const backend = getBackendUrl(context.env);
   if (!backend) {
     return createPlainApiBaseErrorResponse();
   }
 
   const target = buildTargetUrl(backend, context.request);
+  // 不透传客户端 headers，避免泄漏 Cookie / Authorization 给后端代理链路
   const res = await fetch(target, {
-    method: context.request.method,
-    headers: context.request.headers,
+    method,
+    headers: { Accept: "text/plain" },
   });
   return new Response(res.body, {
     status: res.status,

--- a/client/functions/robots.txt.ts
+++ b/client/functions/robots.txt.ts
@@ -1,0 +1,23 @@
+import {
+  buildTargetUrl,
+  createPlainApiBaseErrorResponse,
+  getBackendUrl,
+} from "./_shared";
+
+// 代理 /robots.txt 到 Workers 后端
+export const onRequest: PagesFunction<{ API_BASE: string }> = async (context) => {
+  const backend = getBackendUrl(context.env);
+  if (!backend) {
+    return createPlainApiBaseErrorResponse();
+  }
+
+  const target = buildTargetUrl(backend, context.request);
+  const res = await fetch(target, {
+    method: context.request.method,
+    headers: context.request.headers,
+  });
+  return new Response(res.body, {
+    status: res.status,
+    headers: res.headers,
+  });
+};

--- a/client/functions/sitemap.xml.ts
+++ b/client/functions/sitemap.xml.ts
@@ -5,16 +5,26 @@ import {
 } from "./_shared";
 
 // 代理 /sitemap.xml 到 Workers 后端
+// 仅允许 GET/HEAD，避免成为开放 method 转发器
 export const onRequest: PagesFunction<{ API_BASE: string }> = async (context) => {
+  const method = context.request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD", "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
   const backend = getBackendUrl(context.env);
   if (!backend) {
     return createPlainApiBaseErrorResponse();
   }
 
   const target = buildTargetUrl(backend, context.request);
+  // 不透传客户端 headers，避免泄漏 Cookie / Authorization 给后端代理链路
   const res = await fetch(target, {
-    method: context.request.method,
-    headers: context.request.headers,
+    method,
+    headers: { Accept: "application/xml, text/xml" },
   });
   return new Response(res.body, {
     status: res.status,

--- a/client/functions/sitemap.xml.ts
+++ b/client/functions/sitemap.xml.ts
@@ -1,0 +1,23 @@
+import {
+  buildTargetUrl,
+  createPlainApiBaseErrorResponse,
+  getBackendUrl,
+} from "./_shared";
+
+// 代理 /sitemap.xml 到 Workers 后端
+export const onRequest: PagesFunction<{ API_BASE: string }> = async (context) => {
+  const backend = getBackendUrl(context.env);
+  if (!backend) {
+    return createPlainApiBaseErrorResponse();
+  }
+
+  const target = buildTargetUrl(backend, context.request);
+  const res = await fetch(target, {
+    method: context.request.method,
+    headers: context.request.headers,
+  });
+  return new Response(res.body, {
+    status: res.status,
+    headers: res.headers,
+  });
+};

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -22,6 +22,7 @@ const AdminPages = lazy(() => import("@/pages/admin/pages").then((m) => ({ defau
 const AdminComments = lazy(() => import("@/pages/admin/comments").then((m) => ({ default: m.AdminComments })));
 const AdminMedia = lazy(() => import("@/pages/admin/media").then((m) => ({ default: m.AdminMedia })));
 const AdminAnalytics = lazy(() => import("@/pages/admin/analytics").then((m) => ({ default: m.AdminAnalytics })));
+const AdminSeo = lazy(() => import("@/pages/admin/seo").then((m) => ({ default: m.AdminSeo })));
 const PrivacyPage = lazy(() => import("@/pages/privacy").then((m) => ({ default: m.PrivacyPage })));
 const DynamicPage = lazy(() => import("@/pages/dynamic-page").then((m) => ({ default: m.DynamicPage })));
 const NotFoundPage = lazy(() => import("@/pages/not-found").then((m) => ({ default: m.NotFoundPage })));
@@ -165,6 +166,7 @@ export function App() {
                 <Route path="/admin/comments"><AdminComments /></Route>
                 <Route path="/admin/media"><AdminMedia /></Route>
                 <Route path="/admin/analytics"><AdminAnalytics /></Route>
+                <Route path="/admin/seo"><AdminSeo /></Route>
                 <Route path="/admin"><AdminDashboard /></Route>
                 <Route><NotFoundPage /></Route>
               </Switch>

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -8,6 +8,7 @@ import {
   ImageIcon,
   BarChart3,
   HardDrive,
+  Sparkles,
   Settings,
   LogOut,
   ExternalLink,
@@ -51,6 +52,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
       items: [
         { href: "/admin/media", icon: ImageIcon, label: "媒体库" },
         { href: "/admin/analytics", icon: BarChart3, label: "数据分析" },
+        { href: "/admin/seo", icon: Sparkles, label: "SEO 优化" },
         { href: "/admin/backup", icon: HardDrive, label: "安全备份" },
       ],
     },

--- a/client/src/lib/seo-analyzer.ts
+++ b/client/src/lib/seo-analyzer.ts
@@ -1,0 +1,318 @@
+// SEO 分析器：四维评分算法
+
+export interface SeoCheckResult {
+  id: string;
+  label: string;
+  status: "pass" | "warn" | "fail";
+  score: number;
+  detail: string;
+}
+
+export interface PostSeoReport {
+  slug: string;
+  title: string;
+  totalScore: number;
+  passedCount: number;
+  totalCount: number;
+  checks: SeoCheckResult[];
+}
+
+export interface SeoOverview {
+  totalPosts: number;
+  publishedPosts: number;
+  draftPosts: number;
+  totalScore: number;
+  scoreDistribution: { excellent: number; good: number; warn: number; poor: number };
+  dimensionScores: { meta: number; structured: number; content: number; readability: number };
+  globalChecks: SeoCheckResult[];
+  postReports: PostSeoReport[];
+  topKeywords: { word: string; count: number; weight: number }[];
+}
+
+export interface AnalyzeInput {
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  content: string;
+  tags: string[];
+  coverImage: string | null;
+  published: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const CN_STOPWORDS = new Set([
+  "的", "了", "和", "是", "在", "我", "有", "也", "就", "都", "而", "及", "与", "或", "一个", "没有",
+  "这", "那", "你", "他", "她", "它", "我们", "你们", "他们", "自己", "什么", "怎么", "可以", "因为",
+  "所以", "但是", "如果", "虽然", "然后", "因此", "已经", "正在", "可能", "应该", "需要", "对于",
+  "通过", "进行", "使用", "包括", "其他", "这个", "那个", "这样", "那样", "一些", "比如", "例如",
+  "this", "that", "with", "from", "have", "been", "were", "will", "would", "could", "should",
+  "the", "and", "for", "are", "but", "not", "you", "all", "can", "had", "her", "was", "one",
+  "our", "out", "day", "get", "has", "him", "his", "how", "man", "new", "now", "old", "see",
+  "two", "way", "who", "boy", "did", "its", "let", "put", "say", "she", "too", "use",
+]);
+
+/** 去除 Markdown 标记，仅保留可读文本 */
+export function stripMarkdown(md: string): string {
+  return md
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/[*_~>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** 中英混合分词 + 停用词过滤 */
+export function extractKeywords(text: string): Map<string, number> {
+  const counter = new Map<string, number>();
+  const cleaned = stripMarkdown(text).toLowerCase();
+  const englishWords = cleaned.match(/[a-z]{3,}/g) || [];
+  for (const w of englishWords) {
+    if (CN_STOPWORDS.has(w)) continue;
+    counter.set(w, (counter.get(w) || 0) + 1);
+  }
+  const cnText = cleaned.replace(/[a-z0-9\s\p{P}]/gu, "");
+  for (let i = 0; i < cnText.length - 1; i++) {
+    const bigram = cnText.slice(i, i + 2);
+    if (CN_STOPWORDS.has(bigram)) continue;
+    counter.set(bigram, (counter.get(bigram) || 0) + 1);
+  }
+  return counter;
+}
+
+/** 估算阅读时间（分钟） */
+export function estimateReadingMinutes(text: string): number {
+  const cn = (text.match(/[\u4e00-\u9fa5]/g) || []).length;
+  const en = (text.match(/[a-zA-Z]+/g) || []).length;
+  return Math.max(1, Math.round((cn / 400) + (en / 250)));
+}
+
+/** H1/H2/H3 标题层级抽取 */
+export function extractHeadingLevels(md: string): { h1: number; h2: number; h3: number } {
+  const lines = md.split(/\r?\n/);
+  let h1 = 0, h2 = 0, h3 = 0;
+  for (const line of lines) {
+    if (/^#\s+/.test(line)) h1++;
+    else if (/^##\s+/.test(line)) h2++;
+    else if (/^###\s+/.test(line)) h3++;
+  }
+  return { h1, h2, h3 };
+}
+
+/** 检测图片 alt 缺失 */
+export function countImagesWithoutAlt(md: string): { total: number; missing: number } {
+  const imgs = md.match(/!\[([^\]]*)\]\([^)]+\)/g) || [];
+  let missing = 0;
+  for (const img of imgs) {
+    const m = img.match(/!\[([^\]]*)\]/);
+    if (!m || !m[1].trim()) missing++;
+  }
+  return { total: imgs.length, missing };
+}
+
+/** 评估单篇文章的 SEO 健康度，返回 13 项检查结果 */
+export function analyzePost(p: AnalyzeInput): PostSeoReport {
+  const checks: SeoCheckResult[] = [];
+  const titleLen = p.title.trim().length;
+  const excerptLen = (p.excerpt || "").trim().length;
+  const plainText = stripMarkdown(p.content);
+  const wordCount = (plainText.match(/[\u4e00-\u9fa5]/g) || []).length + (plainText.match(/[a-zA-Z]+/g) || []).length;
+  const headings = extractHeadingLevels(p.content);
+  const imgs = countImagesWithoutAlt(p.content);
+  const internalLinks = (p.content.match(/\[[^\]]+\]\(\/[^)]*\)/g) || []).length;
+  const externalLinks = (p.content.match(/\[[^\]]+\]\(https?:\/\/[^)]*\)/g) || []).length;
+  const slugOk = /^[a-z0-9-]+$/.test(p.slug) && !p.slug.includes("--") && !p.slug.startsWith("-") && !p.slug.endsWith("-");
+
+  // === Meta 元信息（4 项） ===
+  checks.push({
+    id: "title-length",
+    label: "标题长度",
+    status: titleLen >= 5 && titleLen <= 60 ? "pass" : titleLen < 5 ? "fail" : "warn",
+    score: titleLen >= 5 && titleLen <= 60 ? 100 : titleLen < 5 ? 0 : 60,
+    detail: `${titleLen} 字符，建议 5-60`,
+  });
+  checks.push({
+    id: "excerpt-length",
+    label: "摘要长度",
+    status: excerptLen >= 60 && excerptLen <= 160 ? "pass" : excerptLen === 0 ? "fail" : "warn",
+    score: excerptLen >= 60 && excerptLen <= 160 ? 100 : excerptLen === 0 ? 0 : 60,
+    detail: excerptLen === 0 ? "未填写" : `${excerptLen} 字符，建议 60-160`,
+  });
+  checks.push({
+    id: "slug-format",
+    label: "URL Slug 规范",
+    status: slugOk ? "pass" : "fail",
+    score: slugOk ? 100 : 0,
+    detail: slugOk ? p.slug : "需为小写字母+数字+短横线",
+  });
+  checks.push({
+    id: "tags-coverage",
+    label: "标签覆盖",
+    status: p.tags.length >= 2 ? "pass" : p.tags.length === 1 ? "warn" : "fail",
+    score: p.tags.length >= 2 ? 100 : p.tags.length === 1 ? 60 : 0,
+    detail: `${p.tags.length} 个标签，建议 2-5`,
+  });
+
+  // === 结构化数据（3 项） ===
+  checks.push({
+    id: "cover-image",
+    label: "封面图（OG）",
+    status: p.coverImage ? "pass" : "warn",
+    score: p.coverImage ? 100 : 50,
+    detail: p.coverImage ? "已设置" : "缺失，社交分享将用默认图",
+  });
+  checks.push({
+    id: "json-ld",
+    label: "JSON-LD 结构化",
+    status: p.published ? "pass" : "warn",
+    score: p.published ? 100 : 50,
+    detail: p.published ? "BlogPosting schema 自动注入" : "草稿不输出结构化数据",
+  });
+  checks.push({
+    id: "canonical",
+    label: "Canonical URL",
+    status: "pass",
+    score: 100,
+    detail: "由 SeoHead 自动注入",
+  });
+
+  // === 内容质量（4 项） ===
+  checks.push({
+    id: "word-count",
+    label: "正文字数",
+    status: wordCount >= 300 ? "pass" : wordCount >= 100 ? "warn" : "fail",
+    score: wordCount >= 300 ? 100 : wordCount >= 100 ? 60 : 20,
+    detail: `${wordCount} 字，建议 ≥300`,
+  });
+  checks.push({
+    id: "heading-structure",
+    label: "标题层级",
+    status: headings.h2 >= 2 ? "pass" : headings.h2 >= 1 ? "warn" : "fail",
+    score: headings.h2 >= 2 ? 100 : headings.h2 >= 1 ? 60 : 20,
+    detail: `H1 ${headings.h1} · H2 ${headings.h2} · H3 ${headings.h3}`,
+  });
+  checks.push({
+    id: "image-alt",
+    label: "图片 Alt",
+    status: imgs.total === 0 ? "pass" : imgs.missing === 0 ? "pass" : imgs.missing < imgs.total ? "warn" : "fail",
+    score: imgs.total === 0 ? 100 : Math.round(((imgs.total - imgs.missing) / imgs.total) * 100),
+    detail: imgs.total === 0 ? "无图片" : `${imgs.total - imgs.missing}/${imgs.total} 含 alt`,
+  });
+  checks.push({
+    id: "links",
+    label: "链接密度",
+    status: internalLinks + externalLinks >= 1 ? "pass" : "warn",
+    score: internalLinks + externalLinks >= 1 ? 100 : 50,
+    detail: `内链 ${internalLinks} · 外链 ${externalLinks}`,
+  });
+
+  // === 可读性 & 性能（2 项） ===
+  const reading = estimateReadingMinutes(plainText);
+  checks.push({
+    id: "reading-time",
+    label: "预计阅读时长",
+    status: reading >= 2 && reading <= 15 ? "pass" : "warn",
+    score: reading >= 2 && reading <= 15 ? 100 : 60,
+    detail: `约 ${reading} 分钟`,
+  });
+  const paragraphs = p.content.split(/\n\n+/).filter(Boolean).length;
+  checks.push({
+    id: "paragraph-density",
+    label: "段落密度",
+    status: paragraphs >= 3 ? "pass" : paragraphs >= 1 ? "warn" : "fail",
+    score: paragraphs >= 3 ? 100 : paragraphs >= 1 ? 60 : 0,
+    detail: `${paragraphs} 段`,
+  });
+
+  const totalScore = Math.round(checks.reduce((s, c) => s + c.score, 0) / checks.length);
+  const passedCount = checks.filter((c) => c.status === "pass").length;
+  return {
+    slug: p.slug,
+    title: p.title,
+    totalScore,
+    passedCount,
+    totalCount: checks.length,
+    checks,
+  };
+}
+
+/** 汇总全站 SEO 概览 */
+export function buildOverview(posts: AnalyzeInput[]): SeoOverview {
+  const reports = posts.map(analyzePost);
+  const published = posts.filter((p) => p.published);
+  const publishedReports = reports.filter((_, i) => posts[i].published);
+
+  const dimAcc = { meta: [0, 0], structured: [0, 0], content: [0, 0], readability: [0, 0] };
+  const dimMap: Record<string, keyof typeof dimAcc> = {
+    "title-length": "meta", "excerpt-length": "meta", "slug-format": "meta", "tags-coverage": "meta",
+    "cover-image": "structured", "json-ld": "structured", "canonical": "structured",
+    "word-count": "content", "heading-structure": "content", "image-alt": "content", "links": "content",
+    "reading-time": "readability", "paragraph-density": "readability",
+  };
+  for (const r of publishedReports) {
+    for (const c of r.checks) {
+      const key = dimMap[c.id];
+      if (key) {
+        dimAcc[key][0] += c.score;
+        dimAcc[key][1] += 1;
+      }
+    }
+  }
+  const dimensionScores = {
+    meta: dimAcc.meta[1] ? Math.round(dimAcc.meta[0] / dimAcc.meta[1]) : 0,
+    structured: dimAcc.structured[1] ? Math.round(dimAcc.structured[0] / dimAcc.structured[1]) : 0,
+    content: dimAcc.content[1] ? Math.round(dimAcc.content[0] / dimAcc.content[1]) : 0,
+    readability: dimAcc.readability[1] ? Math.round(dimAcc.readability[0] / dimAcc.readability[1]) : 0,
+  };
+  const totalScore = Math.round((dimensionScores.meta + dimensionScores.structured + dimensionScores.content + dimensionScores.readability) / 4);
+
+  const dist = { excellent: 0, good: 0, warn: 0, poor: 0 };
+  for (const r of publishedReports) {
+    if (r.totalScore >= 90) dist.excellent++;
+    else if (r.totalScore >= 75) dist.good++;
+    else if (r.totalScore >= 60) dist.warn++;
+    else dist.poor++;
+  }
+
+  const globalChecks: SeoCheckResult[] = [
+    { id: "sitemap", label: "Sitemap.xml", status: "pass", score: 100, detail: "已挂载 /sitemap.xml" },
+    { id: "robots", label: "Robots.txt", status: "pass", score: 100, detail: "已挂载 /robots.txt" },
+    { id: "rss", label: "RSS Feed", status: "pass", score: 100, detail: "已挂载 /rss.xml" },
+    { id: "prerender", label: "爬虫预渲染", status: "pass", score: 100, detail: "Pages Function 自动注入 OG" },
+  ];
+
+  // Top 关键词聚合（基于已发布文章 title + tags + 首段）
+  const kwCounter = new Map<string, number>();
+  for (const p of published) {
+    const sample = p.title + " " + p.tags.join(" ") + " " + stripMarkdown(p.content).slice(0, 600);
+    const local = extractKeywords(sample);
+    for (const [w, c] of local) {
+      if (w.length < 2 || w.length > 8) continue;
+      kwCounter.set(w, (kwCounter.get(w) || 0) + c);
+    }
+  }
+  const topKeywords = Array.from(kwCounter.entries())
+    .filter(([, c]) => c >= 2)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 40)
+    .map(([word, count], i, arr) => ({
+      word,
+      count,
+      weight: arr.length ? count / arr[0][1] : 0,
+    }));
+
+  return {
+    totalPosts: posts.length,
+    publishedPosts: published.length,
+    draftPosts: posts.length - published.length,
+    totalScore,
+    scoreDistribution: dist,
+    dimensionScores,
+    globalChecks,
+    postReports: reports,
+    topKeywords,
+  };
+}

--- a/client/src/lib/seo-analyzer.ts
+++ b/client/src/lib/seo-analyzer.ts
@@ -239,8 +239,18 @@ export function analyzePost(p: AnalyzeInput): PostSeoReport {
   };
 }
 
+/** 站点基础设施实测信号（来自页面端 fetch 结果） */
+export interface SiteInfraSignal {
+  /** sitemap 抓取状态 */
+  sitemap?: { ok: boolean; urlCount: number; error?: string };
+  /** robots 抓取状态 */
+  robots?: { ok: boolean; hasSitemapDirective: boolean; error?: string };
+  /** rss 抓取状态 */
+  rss?: { ok: boolean; error?: string };
+}
+
 /** 汇总全站 SEO 概览 */
-export function buildOverview(posts: AnalyzeInput[]): SeoOverview {
+export function buildOverview(posts: AnalyzeInput[], infra?: SiteInfraSignal): SeoOverview {
   const reports = posts.map(analyzePost);
   const published = posts.filter((p) => p.published);
   const publishedReports = reports.filter((_, i) => posts[i].published);
@@ -278,9 +288,25 @@ export function buildOverview(posts: AnalyzeInput[]): SeoOverview {
   }
 
   const globalChecks: SeoCheckResult[] = [
-    { id: "sitemap", label: "Sitemap.xml", status: "pass", score: 100, detail: "已挂载 /sitemap.xml" },
-    { id: "robots", label: "Robots.txt", status: "pass", score: 100, detail: "已挂载 /robots.txt" },
-    { id: "rss", label: "RSS Feed", status: "pass", score: 100, detail: "已挂载 /rss.xml" },
+    infra?.sitemap
+      ? infra.sitemap.ok && infra.sitemap.urlCount > 0
+        ? { id: "sitemap", label: "Sitemap.xml", status: "pass", score: 100, detail: `已挂载 · ${infra.sitemap.urlCount} URLs` }
+        : infra.sitemap.ok
+        ? { id: "sitemap", label: "Sitemap.xml", status: "warn", score: 60, detail: "可访问但无 URL" }
+        : { id: "sitemap", label: "Sitemap.xml", status: "fail", score: 0, detail: infra.sitemap.error || "抓取失败" }
+      : { id: "sitemap", label: "Sitemap.xml", status: "warn", score: 60, detail: "未检测" },
+    infra?.robots
+      ? infra.robots.ok && infra.robots.hasSitemapDirective
+        ? { id: "robots", label: "Robots.txt", status: "pass", score: 100, detail: "已挂载 · 含 Sitemap 指令" }
+        : infra.robots.ok
+        ? { id: "robots", label: "Robots.txt", status: "warn", score: 70, detail: "缺少 Sitemap 指令" }
+        : { id: "robots", label: "Robots.txt", status: "fail", score: 0, detail: infra.robots.error || "抓取失败" }
+      : { id: "robots", label: "Robots.txt", status: "warn", score: 60, detail: "未检测" },
+    infra?.rss
+      ? infra.rss.ok
+        ? { id: "rss", label: "RSS Feed", status: "pass", score: 100, detail: "已挂载 /rss.xml" }
+        : { id: "rss", label: "RSS Feed", status: "fail", score: 0, detail: infra.rss.error || "抓取失败" }
+      : { id: "rss", label: "RSS Feed", status: "warn", score: 60, detail: "未检测" },
     { id: "prerender", label: "爬虫预渲染", status: "pass", score: 100, detail: "Pages Function 自动注入 OG" },
   ];
 

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -176,8 +176,8 @@ export function AdminDashboard() {
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_220px] gap-[20px]">
 
         {/* ─── 文章列表 ─── */}
-        <div>
-          <div className="mb-[10px] flex items-center justify-between">
+        <div className="flex flex-col min-h-0 lg:max-h-[calc(100vh-260px)]">
+          <div className="mb-[10px] flex items-center justify-between shrink-0">
             <h2 className="text-[12px] font-medium text-muted-foreground/40 uppercase tracking-wider flex items-center gap-[5px]">
               {filter === "all" ? "所有文章" : filter === "published" ? "已发布" : "草稿箱"}
               {selectedTag && <><span className="text-muted-foreground/15">·</span><span className="text-cyan-400 normal-case">{selectedTag}</span></>}
@@ -187,7 +187,7 @@ export function AdminDashboard() {
 
           {/* 批量操作工具栏 */}
           {filteredPosts.length > 0 && (
-            <div className={`mb-[10px] flex items-center justify-between rounded-lg border border-border/15 bg-card/10 px-[14px] py-[8px] transition-all ${selectedSlugs.size > 0 ? "border-cyan-500/30 bg-cyan-500/5" : ""}`}>
+            <div className={`mb-[10px] flex items-center justify-between rounded-lg border border-border/15 bg-card/10 px-[14px] py-[8px] transition-all shrink-0 ${selectedSlugs.size > 0 ? "border-cyan-500/30 bg-cyan-500/5" : ""}`}>
               <div className="flex items-center gap-[10px]">
                 <button onClick={toggleSelectAll} className="text-muted-foreground/40 hover:text-cyan-400 transition-colors flex items-center gap-[6px]">
                   {selectedSlugs.size === filteredPosts.length ? <CheckSquare className="h-[14px] w-[14px] text-cyan-400" /> : <Square className="h-[14px] w-[14px]" />}
@@ -212,9 +212,9 @@ export function AdminDashboard() {
           )}
 
           {loading ? (
-            <div className="space-y-[6px]">{[1, 2, 3].map((i) => <div key={i} className="h-[72px] animate-pulse rounded-lg border border-border/10 bg-card/5" />)}</div>
+            <div className="space-y-[6px] shrink-0">{[1, 2, 3].map((i) => <div key={i} className="h-[72px] animate-pulse rounded-lg border border-border/10 bg-card/5" />)}</div>
           ) : filteredPosts.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-border/20 py-[52px] text-center">
+            <div className="rounded-lg border border-dashed border-border/20 py-[52px] text-center shrink-0">
               <FileText className="mx-auto mb-[12px] h-[24px] w-[24px] text-muted-foreground/10" />
               <p className="text-[13px] text-muted-foreground/30 mb-[12px]">
                 {search || selectedTag ? "没有符合条件的文章" : "暂无文章"}
@@ -226,7 +226,8 @@ export function AdminDashboard() {
               )}
             </div>
           ) : (
-            <div className="space-y-[4px]">
+            <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain pr-[4px] -mr-[4px] scrollbar-thin">
+              <div className="space-y-[4px]">
               {filteredPosts.map((post) => (
                 <div key={post.slug} className={`group relative flex items-center gap-[12px] rounded-lg border px-[14px] py-[12px] transition-all ${selectedSlugs.has(post.slug) ? "border-cyan-500/30 bg-cyan-500/5 text-cyan-400" : "border-border/12 bg-card/5 hover:border-border/35 hover:bg-card/20"}`}>
                   
@@ -264,6 +265,7 @@ export function AdminDashboard() {
                   </div>
                 </div>
               ))}
+              </div>
             </div>
           )}
         </div>

--- a/client/src/pages/admin/seo.tsx
+++ b/client/src/pages/admin/seo.tsx
@@ -1,0 +1,343 @@
+import { useState, useEffect, useMemo } from "react";
+import { Link } from "wouter";
+import { fetchAdminPosts, type Post } from "@/lib/api";
+import { CheckCircle2, AlertTriangle, XCircle, FileText, Search, ExternalLink, RefreshCw, Edit, Sparkles } from "lucide-react";
+import { buildOverview, type SeoOverview, type SeoCheckResult } from "@/lib/seo-analyzer";
+
+type FilterTab = "all" | "warn" | "poor" | "drafts";
+
+function ScoreRing({ score, size = 140, stroke = 10, label }: { score: number; size?: number; stroke?: number; label: string }) {
+  const r = (size - stroke) / 2;
+  const c = 2 * Math.PI * r;
+  const dash = (score / 100) * c;
+  const color = score >= 90 ? "stroke-emerald-400" : score >= 75 ? "stroke-cyan-400" : score >= 60 ? "stroke-amber-400" : "stroke-red-400";
+  const colorBg = score >= 90 ? "text-emerald-400" : score >= 75 ? "text-cyan-400" : score >= 60 ? "text-amber-400" : "text-red-400";
+  return (
+    <div className="flex flex-col items-center gap-[6px]">
+      <div className="relative" style={{ width: size, height: size }}>
+        <svg width={size} height={size} className="-rotate-90">
+          <circle cx={size / 2} cy={size / 2} r={r} fill="none" strokeWidth={stroke} className="stroke-border/20" />
+          <circle cx={size / 2} cy={size / 2} r={r} fill="none" strokeWidth={stroke} strokeLinecap="round"
+            strokeDasharray={`${dash} ${c}`} className={`${color} transition-all duration-700`}
+            style={{ transitionTimingFunction: "cubic-bezier(0.16, 1, 0.3, 1)" }} />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className={`text-[28px] font-bold leading-none tracking-tight ${colorBg}`}>{score}</span>
+          <span className="text-[10px] text-muted-foreground/50 mt-[2px] font-medium">/ 100</span>
+        </div>
+      </div>
+      <span className="text-[12px] text-muted-foreground/70 font-medium">{label}</span>
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: SeoCheckResult["status"] }) {
+  if (status === "pass") return <CheckCircle2 className="h-[14px] w-[14px] text-emerald-400" />;
+  if (status === "warn") return <AlertTriangle className="h-[14px] w-[14px] text-amber-400" />;
+  return <XCircle className="h-[14px] w-[14px] text-red-400" />;
+}
+
+export function AdminSeo() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [search, setSearch] = useState("");
+  const [tab, setTab] = useState<FilterTab>("all");
+  const [sitemapPreview, setSitemapPreview] = useState<{ urls: string[]; raw: string } | null>(null);
+  const [robotsPreview, setRobotsPreview] = useState<string>("");
+
+  const loadAll = async () => {
+    setRefreshing(true);
+    try {
+      const list = await fetchAdminPosts();
+      setPosts(list);
+      const [smRes, rbRes] = await Promise.all([
+        fetch("/sitemap.xml").then((r) => (r.ok ? r.text() : "")),
+        fetch("/robots.txt").then((r) => (r.ok ? r.text() : "")),
+      ]);
+      const urls = Array.from(smRes.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1]);
+      setSitemapPreview({ urls, raw: smRes });
+      setRobotsPreview(rbRes);
+    } finally {
+      setRefreshing(false);
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    document.title = "SEO 优化 | Monolith";
+    loadAll();
+  }, []);
+
+  const overview: SeoOverview = useMemo(() => {
+    return buildOverview(posts.map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      excerpt: p.excerpt,
+      content: p.content,
+      tags: p.tags,
+      coverImage: p.coverImage,
+      published: p.published,
+      createdAt: p.createdAt,
+      updatedAt: p.updatedAt,
+    })));
+  }, [posts]);
+
+  const filteredReports = useMemo(() => {
+    let result = overview.postReports;
+    const slugSet = new Set(posts.filter((p) => {
+      if (tab === "drafts") return !p.published;
+      return p.published;
+    }).map((p) => p.slug));
+    result = result.filter((r) => slugSet.has(r.slug));
+    if (tab === "warn") result = result.filter((r) => r.totalScore >= 60 && r.totalScore < 90);
+    if (tab === "poor") result = result.filter((r) => r.totalScore < 60);
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      result = result.filter((r) => r.title.toLowerCase().includes(q) || r.slug.toLowerCase().includes(q));
+    }
+    return result.sort((a, b) => a.totalScore - b.totalScore);
+  }, [overview.postReports, posts, tab, search]);
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-[1200px] px-[16px] py-[28px]">
+        <div className="space-y-[16px]">
+          <div className="h-[28px] w-[140px] bg-card/20 animate-pulse rounded" />
+          <div className="grid grid-cols-5 gap-[12px]">
+            {[...Array(5)].map((_, i) => (<div key={i} className="h-[160px] rounded-xl bg-card/10 animate-pulse" />))}
+          </div>
+          <div className="h-[300px] rounded-xl bg-card/10 animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-[1200px] px-[16px] py-[28px] space-y-[20px]">
+      {/* ═══════════ 头部 ═══════════ */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-[22px] font-bold leading-tight tracking-tight flex items-center gap-[8px]">
+            <Sparkles className="h-[20px] w-[20px] text-cyan-400" />
+            SEO 优化
+          </h1>
+          <p className="text-[12px] text-muted-foreground/60 mt-[4px]">
+            站点搜索引擎健康度全景，覆盖 Meta · 结构化 · 内容质量 · 可读性
+          </p>
+        </div>
+        <button onClick={loadAll} disabled={refreshing}
+          className="inline-flex items-center gap-[6px] h-[34px] px-[12px] rounded-lg border border-border/20 bg-card/10 text-[12px] font-medium hover:bg-card/20 transition-all disabled:opacity-50">
+          <RefreshCw className={`h-[12px] w-[12px] ${refreshing ? "animate-spin" : ""}`} />
+          刷新
+        </button>
+      </div>
+
+      {/* ═══════════ 评分环组 ═══════════ */}
+      <div className="rounded-xl border border-border/15 bg-card/5 p-[20px]">
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-[16px] items-center">
+          <div className="md:col-span-1 flex justify-center">
+            <ScoreRing score={overview.totalScore} size={150} stroke={12} label="综合得分" />
+          </div>
+          <div className="md:col-span-4 grid grid-cols-2 sm:grid-cols-4 gap-[12px]">
+            <ScoreRing score={overview.dimensionScores.meta} size={100} stroke={8} label="Meta 元信息" />
+            <ScoreRing score={overview.dimensionScores.structured} size={100} stroke={8} label="结构化数据" />
+            <ScoreRing score={overview.dimensionScores.content} size={100} stroke={8} label="内容质量" />
+            <ScoreRing score={overview.dimensionScores.readability} size={100} stroke={8} label="可读性" />
+          </div>
+        </div>
+
+        {/* 分布趋势条 */}
+        <div className="mt-[20px] pt-[16px] border-t border-border/10">
+          <div className="flex items-center justify-between mb-[8px]">
+            <span className="text-[11px] uppercase tracking-wider text-muted-foreground/50 font-medium">已发布文章评分分布</span>
+            <span className="text-[11px] text-muted-foreground/60">{overview.publishedPosts} 篇 · 草稿 {overview.draftPosts} 篇</span>
+          </div>
+          <div className="flex h-[10px] rounded-full overflow-hidden bg-card/20">
+            {([
+              ["excellent", overview.scoreDistribution.excellent, "bg-emerald-400/80", "≥90"],
+              ["good", overview.scoreDistribution.good, "bg-cyan-400/80", "75-89"],
+              ["warn", overview.scoreDistribution.warn, "bg-amber-400/80", "60-74"],
+              ["poor", overview.scoreDistribution.poor, "bg-red-400/80", "<60"],
+            ] as const).map(([k, v, c]) => (
+              v > 0 && <div key={k} className={`${c} transition-all duration-700`} style={{ flex: v }} title={`${v} 篇`} />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-[12px] mt-[8px] text-[11px] text-muted-foreground/70">
+            <span className="flex items-center gap-[5px]"><span className="w-[8px] h-[8px] rounded-full bg-emerald-400/80" />优秀 {overview.scoreDistribution.excellent}</span>
+            <span className="flex items-center gap-[5px]"><span className="w-[8px] h-[8px] rounded-full bg-cyan-400/80" />良好 {overview.scoreDistribution.good}</span>
+            <span className="flex items-center gap-[5px]"><span className="w-[8px] h-[8px] rounded-full bg-amber-400/80" />一般 {overview.scoreDistribution.warn}</span>
+            <span className="flex items-center gap-[5px]"><span className="w-[8px] h-[8px] rounded-full bg-red-400/80" />待改 {overview.scoreDistribution.poor}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ═══════════ 全局基础设施检查 ═══════════ */}
+      <div className="rounded-xl border border-border/15 bg-card/5 p-[16px]">
+        <h2 className="text-[13px] font-semibold mb-[12px] flex items-center gap-[6px]">
+          <FileText className="h-[14px] w-[14px] text-muted-foreground/60" />
+          站点基础设施
+        </h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-[8px]">
+          {overview.globalChecks.map((c) => (
+            <div key={c.id} className="flex items-start gap-[8px] rounded-lg border border-border/10 bg-card/5 p-[10px]">
+              <StatusIcon status={c.status} />
+              <div className="flex-1 min-w-0">
+                <div className="text-[12px] font-medium leading-tight">{c.label}</div>
+                <div className="text-[10px] text-muted-foreground/60 mt-[2px] truncate">{c.detail}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ═══════════ 文章健康表 ═══════════ */}
+      <div className="rounded-xl border border-border/15 bg-card/5">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-[10px] p-[16px] border-b border-border/10">
+          <h2 className="text-[13px] font-semibold flex items-center gap-[6px]">
+            <FileText className="h-[14px] w-[14px] text-muted-foreground/60" />
+            文章 SEO 健康表
+          </h2>
+          <div className="flex items-center gap-[6px]">
+            <div className="flex rounded-lg border border-border/15 overflow-hidden text-[11px]">
+              {([
+                ["all", "全部"],
+                ["warn", "待优化"],
+                ["poor", "待改进"],
+                ["drafts", "草稿"],
+              ] as const).map(([k, label]) => (
+                <button key={k} onClick={() => setTab(k)}
+                  className={`px-[10px] h-[28px] font-medium transition-colors ${tab === k ? "bg-foreground text-background" : "bg-transparent hover:bg-card/20 text-muted-foreground/70"}`}>
+                  {label}
+                </button>
+              ))}
+            </div>
+            <div className="relative">
+              <Search className="absolute left-[8px] top-1/2 -translate-y-1/2 h-[12px] w-[12px] text-muted-foreground/40" />
+              <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="搜索标题/slug"
+                className="h-[28px] w-[180px] rounded-lg border border-border/15 bg-card/10 pl-[28px] pr-[10px] text-[11px] outline-none focus:border-cyan-400/50" />
+            </div>
+          </div>
+        </div>
+        {filteredReports.length === 0 ? (
+          <div className="py-[40px] text-center text-[12px] text-muted-foreground/50">没有符合条件的文章</div>
+        ) : (
+          <div className="max-h-[480px] overflow-y-auto overscroll-contain scrollbar-thin">
+            <table className="w-full text-[12px]">
+              <thead className="sticky top-0 bg-card/40 backdrop-blur-sm z-10">
+                <tr className="text-[10px] uppercase tracking-wider text-muted-foreground/50">
+                  <th className="text-left font-medium py-[8px] px-[12px] w-[60px]">分</th>
+                  <th className="text-left font-medium py-[8px] px-[12px]">标题</th>
+                  <th className="text-left font-medium py-[8px] px-[12px] w-[120px]">通过</th>
+                  <th className="text-left font-medium py-[8px] px-[12px] w-[80px]">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredReports.map((r) => {
+                  const failed = r.checks.filter((c) => c.status !== "pass");
+                  const scoreClass = r.totalScore >= 90 ? "text-emerald-400 bg-emerald-400/10" : r.totalScore >= 75 ? "text-cyan-400 bg-cyan-400/10" : r.totalScore >= 60 ? "text-amber-400 bg-amber-400/10" : "text-red-400 bg-red-400/10";
+                  return (
+                    <tr key={r.slug} className="border-t border-border/10 hover:bg-card/10 transition-colors">
+                      <td className="py-[10px] px-[12px]">
+                        <span className={`inline-flex items-center justify-center min-w-[36px] h-[24px] rounded-md text-[12px] font-bold tabular-nums ${scoreClass}`}>{r.totalScore}</span>
+                      </td>
+                      <td className="py-[10px] px-[12px]">
+                        <div className="font-medium text-[12px] truncate max-w-[420px]">{r.title}</div>
+                        {failed.length > 0 && (
+                          <div className="flex flex-wrap gap-[4px] mt-[4px]">
+                            {failed.slice(0, 4).map((f) => (
+                              <span key={f.id} className="inline-flex items-center gap-[3px] text-[10px] px-[5px] py-[1px] rounded bg-card/30 text-muted-foreground/70" title={f.detail}>
+                                <StatusIcon status={f.status} />{f.label}
+                              </span>
+                            ))}
+                            {failed.length > 4 && <span className="text-[10px] text-muted-foreground/50">+{failed.length - 4}</span>}
+                          </div>
+                        )}
+                      </td>
+                      <td className="py-[10px] px-[12px] tabular-nums text-muted-foreground/70">{r.passedCount} / {r.totalCount}</td>
+                      <td className="py-[10px] px-[12px]">
+                        <div className="flex items-center gap-[6px]">
+                          <Link href={`/admin/editor/${r.slug}`} className="text-muted-foreground/60 hover:text-foreground transition-colors" title="编辑">
+                            <Edit className="h-[12px] w-[12px]" />
+                          </Link>
+                          <a href={`/posts/${r.slug}`} target="_blank" rel="noopener noreferrer" className="text-muted-foreground/60 hover:text-foreground transition-colors" title="访问">
+                            <ExternalLink className="h-[12px] w-[12px]" />
+                          </a>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* ═══════════ 关键词云 ═══════════ */}
+      {overview.topKeywords.length > 0 && (
+        <div className="rounded-xl border border-border/15 bg-card/5 p-[16px]">
+          <h2 className="text-[13px] font-semibold mb-[12px] flex items-center gap-[6px]">
+            <Sparkles className="h-[14px] w-[14px] text-muted-foreground/60" />
+            关键词密度云
+            <span className="text-[10px] text-muted-foreground/50 font-normal ml-[4px]">基于已发布文章 title + tags + 首段</span>
+          </h2>
+          <div className="flex flex-wrap items-baseline gap-x-[10px] gap-y-[4px]">
+            {overview.topKeywords.map((k) => {
+              const fontSize = 11 + Math.round(k.weight * 14);
+              const opacity = 0.45 + k.weight * 0.55;
+              return (
+                <span key={k.word} style={{ fontSize: `${fontSize}px`, opacity }}
+                  className="font-medium text-foreground hover:text-cyan-400 transition-colors cursor-default" title={`${k.count} 次`}>
+                  {k.word}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* ═══════════ Sitemap / Robots 预览 ═══════════ */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-[12px]">
+        <div className="rounded-xl border border-border/15 bg-card/5">
+          <div className="flex items-center justify-between p-[12px] border-b border-border/10">
+            <h2 className="text-[12px] font-semibold flex items-center gap-[6px]">
+              <FileText className="h-[12px] w-[12px] text-muted-foreground/60" />
+              Sitemap.xml
+              {sitemapPreview && <span className="text-[10px] text-muted-foreground/50 font-normal">{sitemapPreview.urls.length} URLs</span>}
+            </h2>
+            <a href="/sitemap.xml" target="_blank" rel="noopener noreferrer" className="text-muted-foreground/60 hover:text-foreground transition-colors" title="新窗口打开">
+              <ExternalLink className="h-[12px] w-[12px]" />
+            </a>
+          </div>
+          <div className="max-h-[260px] overflow-y-auto overscroll-contain scrollbar-thin p-[10px] space-y-[2px]">
+            {sitemapPreview?.urls.length ? (
+              sitemapPreview.urls.map((u, i) => (
+                <a key={i} href={u} target="_blank" rel="noopener noreferrer"
+                  className="block text-[11px] font-mono text-muted-foreground/70 hover:text-cyan-400 truncate transition-colors">
+                  {u}
+                </a>
+              ))
+            ) : (
+              <div className="text-[11px] text-muted-foreground/50 py-[12px] text-center">未抓取到 URL</div>
+            )}
+          </div>
+        </div>
+        <div className="rounded-xl border border-border/15 bg-card/5">
+          <div className="flex items-center justify-between p-[12px] border-b border-border/10">
+            <h2 className="text-[12px] font-semibold flex items-center gap-[6px]">
+              <FileText className="h-[12px] w-[12px] text-muted-foreground/60" />
+              Robots.txt
+            </h2>
+            <a href="/robots.txt" target="_blank" rel="noopener noreferrer" className="text-muted-foreground/60 hover:text-foreground transition-colors" title="新窗口打开">
+              <ExternalLink className="h-[12px] w-[12px]" />
+            </a>
+          </div>
+          <pre className="max-h-[260px] overflow-y-auto overscroll-contain scrollbar-thin p-[10px] text-[11px] font-mono text-muted-foreground/80 whitespace-pre-wrap leading-[1.6]">
+            {robotsPreview || "未拉取到 robots.txt"}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/admin/seo.tsx
+++ b/client/src/pages/admin/seo.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { Link } from "wouter";
 import { fetchAdminPosts, type Post } from "@/lib/api";
 import { CheckCircle2, AlertTriangle, XCircle, FileText, Search, ExternalLink, RefreshCw, Edit, Sparkles } from "lucide-react";
-import { buildOverview, type SeoOverview, type SeoCheckResult } from "@/lib/seo-analyzer";
+import { buildOverview, type SeoOverview, type SeoCheckResult, type SiteInfraSignal } from "@/lib/seo-analyzer";
 
 type FilterTab = "all" | "warn" | "poor" | "drafts";
 
@@ -45,23 +45,52 @@ export function AdminSeo() {
   const [tab, setTab] = useState<FilterTab>("all");
   const [sitemapPreview, setSitemapPreview] = useState<{ urls: string[]; raw: string } | null>(null);
   const [robotsPreview, setRobotsPreview] = useState<string>("");
+  const [infra, setInfra] = useState<SiteInfraSignal>({});
+  const [error, setError] = useState<string | null>(null);
 
   const loadAll = async () => {
     setRefreshing(true);
-    try {
-      const list = await fetchAdminPosts();
-      setPosts(list);
-      const [smRes, rbRes] = await Promise.all([
-        fetch("/sitemap.xml").then((r) => (r.ok ? r.text() : "")),
-        fetch("/robots.txt").then((r) => (r.ok ? r.text() : "")),
-      ]);
-      const urls = Array.from(smRes.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1]);
-      setSitemapPreview({ urls, raw: smRes });
-      setRobotsPreview(rbRes);
-    } finally {
-      setRefreshing(false);
-      setLoading(false);
+    setError(null);
+    const [postsResult, smResult, rbResult, rssResult] = await Promise.allSettled([
+      fetchAdminPosts(),
+      fetch("/sitemap.xml").then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`)))),
+      fetch("/robots.txt").then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`)))),
+      fetch("/rss.xml", { method: "HEAD" }).then((r) => (r.ok ? true : Promise.reject(new Error(`HTTP ${r.status}`)))),
+    ]);
+
+    if (postsResult.status === "fulfilled") {
+      setPosts(postsResult.value);
+    } else {
+      setError(postsResult.reason instanceof Error ? postsResult.reason.message : "文章加载失败");
     }
+
+    const nextInfra: SiteInfraSignal = {};
+    if (smResult.status === "fulfilled") {
+      const raw = smResult.value;
+      const urls = Array.from(raw.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1]);
+      setSitemapPreview({ urls, raw });
+      nextInfra.sitemap = { ok: true, urlCount: urls.length };
+    } else {
+      setSitemapPreview({ urls: [], raw: "" });
+      nextInfra.sitemap = { ok: false, urlCount: 0, error: smResult.reason instanceof Error ? smResult.reason.message : "抓取失败" };
+    }
+
+    if (rbResult.status === "fulfilled") {
+      const raw = rbResult.value;
+      setRobotsPreview(raw);
+      nextInfra.robots = { ok: true, hasSitemapDirective: /^\s*sitemap\s*:/im.test(raw) };
+    } else {
+      setRobotsPreview("");
+      nextInfra.robots = { ok: false, hasSitemapDirective: false, error: rbResult.reason instanceof Error ? rbResult.reason.message : "抓取失败" };
+    }
+
+    nextInfra.rss = rssResult.status === "fulfilled"
+      ? { ok: true }
+      : { ok: false, error: rssResult.reason instanceof Error ? rssResult.reason.message : "抓取失败" };
+
+    setInfra(nextInfra);
+    setRefreshing(false);
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -80,18 +109,22 @@ export function AdminSeo() {
       published: p.published,
       createdAt: p.createdAt,
       updatedAt: p.updatedAt,
-    })));
-  }, [posts]);
+    })), infra);
+  }, [posts, infra]);
 
   const filteredReports = useMemo(() => {
     let result = overview.postReports;
-    const slugSet = new Set(posts.filter((p) => {
-      if (tab === "drafts") return !p.published;
-      return p.published;
-    }).map((p) => p.slug));
-    result = result.filter((r) => slugSet.has(r.slug));
-    if (tab === "warn") result = result.filter((r) => r.totalScore >= 60 && r.totalScore < 90);
-    if (tab === "poor") result = result.filter((r) => r.totalScore < 60);
+    if (tab === "drafts") {
+      const draftSlugs = new Set(posts.filter((p) => !p.published).map((p) => p.slug));
+      result = result.filter((r) => draftSlugs.has(r.slug));
+    } else if (tab === "warn" || tab === "poor") {
+      // warn / poor 只评估已发布文章，避免把待发草稿混入"待优化"统计
+      const pubSlugs = new Set(posts.filter((p) => p.published).map((p) => p.slug));
+      result = result.filter((r) => pubSlugs.has(r.slug));
+      if (tab === "warn") result = result.filter((r) => r.totalScore >= 60 && r.totalScore < 90);
+      else result = result.filter((r) => r.totalScore < 60);
+    }
+    // tab === "all": 不按发布状态过滤，真正展示全部文章
     if (search.trim()) {
       const q = search.toLowerCase();
       result = result.filter((r) => r.title.toLowerCase().includes(q) || r.slug.toLowerCase().includes(q));
@@ -132,6 +165,16 @@ export function AdminSeo() {
           刷新
         </button>
       </div>
+
+      {error && (
+        <div className="flex items-start gap-[8px] rounded-lg border border-red-400/30 bg-red-400/5 px-[12px] py-[10px]">
+          <XCircle className="h-[14px] w-[14px] text-red-400 mt-[2px] shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-[12px] font-medium text-red-400">数据加载失败</div>
+            <div className="text-[11px] text-muted-foreground/70 mt-[2px] break-all">{error}</div>
+          </div>
+        </div>
+      )}
 
       {/* ═══════════ 评分环组 ═══════════ */}
       <div className="rounded-xl border border-border/15 bg-card/5 p-[20px]">

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -21,6 +21,7 @@ type Bindings = {
   DB_PROVIDER?: string;
   STORAGE_PROVIDER?: string;
   WEBHOOK_URLS?: string; // 逗号分隔的 Webhook 目标地址
+  SITE_ORIGIN?: string; // 对外公开域名（如 https://monolith-client.pages.dev），用于 sitemap/robots
 };
 
 type Variables = {
@@ -369,7 +370,7 @@ ${items}
 // sitemap.xml — 动态站点地图
 app.get("/sitemap.xml", async (c) => {
   const db = c.get("db");
-  const siteUrl = new URL(c.req.url).origin;
+  const siteUrl = c.env.SITE_ORIGIN || new URL(c.req.url).origin;
 
   const allPosts = await db.getRecentPublishedPosts(1000);
   const allPages = await db.getPublishedPages();
@@ -424,7 +425,7 @@ ${urls.join("\n")}
 
 // robots.txt — 爬虫规则
 app.get("/robots.txt", (c) => {
-  const siteUrl = new URL(c.req.url).origin;
+  const siteUrl = c.env.SITE_ORIGIN || new URL(c.req.url).origin;
   const txt = `User-agent: *
 Allow: /
 Disallow: /admin

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -6,6 +6,8 @@ compatibility_flags = ["nodejs_compat"]
 [vars]
 # 非敏感配置变量（敏感的用 wrangler secret put）
 BLOG_NAME = "Monolith"
+# 对外公开域名（用于 sitemap.xml / robots.txt 的绝对 URL）
+SITE_ORIGIN = "https://monolith-client.pages.dev"
 
 # D1 数据库绑定
 [[d1_databases]]


### PR DESCRIPTION
## 变更摘要

新增管理后台 SEO 仪表盘，并修复 sitemap/robots 在 Pages 域下被 SPA fallback 截胡 + 后端 \`<loc>\` 误用 Workers 自身域名两个问题。

## 主要改动

### 前端
- 新增 \`client/src/lib/seo-analyzer.ts\`（318 行）— SEO 评分算法
- 新增 \`client/src/pages/admin/seo.tsx\`（343 行）— SEO 仪表盘页面
- \`client/src/components/admin-layout.tsx\` — 加 SEO 入口导航
- \`client/src/app.tsx\` — 注册 \`/admin/seo\` lazy route
- \`client/src/pages/admin/dashboard.tsx\` — 文章列表独立滚动容器

### Pages Functions
- 新增 \`client/functions/sitemap.xml.ts\` — 代理 \`/sitemap.xml\` 到 Workers，Content-Type 透传 \`application/xml\`
- 新增 \`client/functions/robots.txt.ts\` — 代理 \`/robots.txt\` 到 Workers，Content-Type 透传 \`text/plain\`

### Workers
- \`server/src/index.ts\` — Bindings 加 \`SITE_ORIGIN?\`，sitemap/robots 路由优先读取该 env，软回退 \`new URL(c.req.url).origin\`
- \`server/wrangler.toml\` — 配置 \`SITE_ORIGIN = "https://monolith-client.pages.dev"\`

## 测试结果

预览部署 https://ebf37c58.monolith-client.pages.dev 已验证：

| 端点 | Content-Type | 内容 |
|------|--------------|------|
| \`/sitemap.xml\` | \`application/xml\` ✅ | 14 个 \`<loc>\` 全部以 \`https://monolith-client.pages.dev\` 开头 |
| \`/robots.txt\` | \`text/plain\` ✅ | \`Sitemap:\` 指向 \`https://monolith-client.pages.dev/sitemap.xml\` |
| \`/admin/seo\` | HTTP 200 ✅ | SEO 仪表盘渲染正常 |
| \`/api/health\` | HTTP 200 ✅ | Workers 健康 |

typecheck（client functions + server）零错误。

## 风险评估

- 新增字段 \`SITE_ORIGIN\` 为 optional，env 缺失时软回退到原行为，向下兼容
- Pages Functions 新增 2 个端点都是纯透传代理，无业务逻辑
- 文章列表滚动容器改造仅影响 \`/admin\` 视觉，不动数据