### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monolith",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monolith",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "workspaces": [
         "client",
         "server"
@@ -20,7 +20,7 @@
     },
     "client": {
       "name": "monolith-client",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@monaco-editor/react": "^4.7.0",
@@ -14824,7 +14824,7 @@
     },
     "server": {
       "name": "monolith-server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1024.0",
         "@libsql/client": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## v2.2.0 — SEO 优化模块

### ✨ 新功能
- 后台「SEO 优化」仪表盘（`/admin/seo`）：综合得分 + 4 维度评分环 + 评分分布 + 文章健康表 + 关键词云 + Sitemap/Robots 实时预览
- 站点基础设施实测（基于真实 fetch 信号的 sitemap / robots / rss 状态判定）
- 文章 SEO 评分算法（Meta / 结构化 / 内容 / 可读性 4 维 18 项）

### 🔧 修复
- Pages Functions 显式代理 \`/sitemap.xml\` 与 \`/robots.txt\`，绕过 SPA fallback 截胡
- 后端 sitemap/robots 路由支持 \`SITE_ORIGIN\` env，\`<loc>\` 正确显示对外 Pages 域名
- Pages Functions 收紧：仅允许 GET/HEAD，不透传客户端 headers
- SEO 仪表盘 \`loadAll\` 用 Promise.allSettled 隔离多路请求 + 错误 banner

### 📦 版本号
\`2.1.0\` → \`2.2.0\`（package.json × 3 + lockfile 同步）

合并后将创建 \`v2.2.0\` Release。