### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monolith",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monolith",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "workspaces": [
         "client",
         "server"
@@ -20,7 +20,7 @@
     },
     "client": {
       "name": "monolith-client",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@monaco-editor/react": "^4.7.0",
@@ -14824,7 +14824,7 @@
     },
     "server": {
       "name": "monolith-server",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1024.0",
         "@libsql/client": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-server",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## v2.3.0 — Cloudflare Analytics Engine 全维度埋点

### 新增能力
- AE Worker 端原生埋点 `POST /api/track`，写入 BLOG_ANALYTICS 数据集
- 客户端 `tracker.js` + `analytics.ts` 自动采集（路径/UA/语言/屏幕/停留）
- 后台新增 AE Tab：访客时序 / 国家 / 引荐 / 设备 / 浏览器 / OS / 页面 / 屏幕 / 语言
- 扩展维度：每周热力图 / 停留分桶 / 入口出口 / 新老访客 / 跳出率 / 人均页数 / 引荐 Top 20

### 关键修复
- AE SQL 严格子集兼容：移除全部 `multiIf` / `if()` / `countIf` / `argMin` / `CASE WHEN`
- 改用「多查询并发 + JS 端组装」模式实现条件分支
- 部署脚本兼容 wrangler ASCII commit-message 限制

### 风险
- AE 数据保留 31 天，长窗口查询自然降级
- 单 visitor_id 基于 cookie，浏览器隔离环境会重复计数（已知行为）