### PR TITLE
fix(auth): 适配 Bitwarden / 1Password 密码管理器自动填充

### DIFF
--- a/client/src/components/admin-gate.tsx
+++ b/client/src/components/admin-gate.tsx
@@ -92,7 +92,7 @@ export function AdminGate({
               验证中...
             </div>
           ) : (
-            <form onSubmit={handleSubmit}>
+            <form onSubmit={handleSubmit} aria-label="管理员登录">
               <div className="mb-[16px] text-center">
                 <div className="mx-auto mb-[10px] flex h-[36px] w-[36px] items-center justify-center rounded-lg bg-gradient-to-b from-foreground/8 to-foreground/4 border border-border/20">
                   <span className="text-[16px]">🔐</span>
@@ -102,8 +102,22 @@ export function AdminGate({
                 </p>
               </div>
 
+              {/* 隐藏 username 字段：让 Bitwarden / 1Password / Chrome 等密码管理器识别为登录表单 */}
+              <input
+                type="text"
+                name="username"
+                value="admin"
+                autoComplete="username"
+                readOnly
+                hidden
+                tabIndex={-1}
+                aria-hidden="true"
+              />
+
               <input
                 ref={inputRef}
+                id="admin-gate-password"
+                name="password"
                 type="password"
                 value={password}
                 onChange={(e) => {
@@ -112,6 +126,7 @@ export function AdminGate({
                 }}
                 placeholder="输入密码"
                 autoComplete="current-password"
+                aria-label="管理员密码"
                 className="h-[40px] w-full rounded-lg border border-border/40 bg-background/50 px-[14px] text-[14px] text-foreground placeholder:text-muted-foreground/30 outline-none focus:border-foreground/25 focus:ring-1 focus:ring-foreground/10 transition-all"
               />
 

--- a/client/src/pages/admin/login.tsx
+++ b/client/src/pages/admin/login.tsx
@@ -35,12 +35,27 @@ export function AdminLogin() {
           <h1 className="text-[20px] font-semibold tracking-[-0.01em]">管理后台</h1>
           <p className="mt-[8px] text-[13px] text-muted-foreground">输入密码以进入管理界面</p>
         </div>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-[16px]">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-[16px]" aria-label="管理员登录">
+          {/* 隐藏 username 字段：让 Bitwarden / 1Password / Chrome 等密码管理器识别为登录表单 */}
           <input
+            type="text"
+            name="username"
+            value="admin"
+            autoComplete="username"
+            readOnly
+            hidden
+            tabIndex={-1}
+            aria-hidden="true"
+          />
+          <input
+            id="admin-login-password"
+            name="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="管理密码"
+            autoComplete="current-password"
+            aria-label="管理员密码"
             autoFocus
             className="h-[40px] rounded-md border border-border/60 bg-background/50 px-[12px] text-[14px] text-foreground placeholder:text-muted-foreground/40 outline-none focus:border-foreground/30 transition-colors"
           />


### PR DESCRIPTION
## 问题

主人反馈：Bitwarden 浏览器扩展在管理员登录密码框上没有显示自动填充图标。

## 根因

密码管理器（Bitwarden / 1Password / Chrome 自带）使用启发式扫描表单，必须看到 **username + password 双字段** 才会触发自动填充 UI。

项目中两处管理员登录表单只有孤立的 `<input type="password">`，缺少：
- 配套的 username 字段（即便是 hidden）
- `name` / `id` / `autoComplete` 属性
- form 的 `aria-label` 语义

导致密码管理器无法识别为登录表单。

## 修复

按 W3C "Sign-in form best practices" 推荐的 **hidden username** 模式补全表单语义：

### `client/src/components/admin-gate.tsx`（首页弹窗）
- 增加 `<input type="text" name="username" autoComplete="username" hidden readOnly>`
- password input 增加 `name="password"`、`id`、`aria-label`
- form 增加 `aria-label="管理员登录"`

### `client/src/pages/admin/login.tsx`（独立登录页）
- 同上 hidden username
- 补全此前缺失的 `autoComplete="current-password"`
- 补 `name` / `id` / `aria-label`

## 验证

- 不影响视觉（纯语义/无障碍属性，未触碰任何 className）
- 不影响交互（hidden input 不渲染、不参与 tab 顺序）
- 不影响后端（后端仍只读取 `password` 字段）

## 关联规则

- UI 设计规范：未触碰间距/颜色/字号
- 双主题/响应式：N/A（无视觉变化）
- Conventional Commits: `fix(auth):`