### PR TITLE
chore(release): v2.3.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-client",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "monolith",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "monolith",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "workspaces": [
         "client",
         "server"
@@ -20,7 +20,7 @@
     },
     "client": {
       "name": "monolith-client",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@monaco-editor/react": "^4.7.0",
@@ -14824,7 +14824,7 @@
     },
     "server": {
       "name": "monolith-server",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1024.0",
         "@libsql/client": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 版本概要

v2.3.1 patch release，修复 v2.3.0 后两个用户反馈缺陷。

## 包含内容

### #56 fix(deploy): 绕过 npm workspace shim 直接调 wrangler 迁移
**修 XBro Win11 v2.3.0 部署在「应用远程数据库迁移」步骤静默退出**

- 根因：spawnSync 调 `npm run db:migrate:remote` 经过 npm workspace shim 多层链路，npm 11 + Win11 + stdio:inherit 已知 bug 导致子进程瞬间 exit 0 但根本没启动 wrangler
- 修复：直接 `npx wrangler d1 migrations apply monolith-db --remote`（cwd=server）绕开 shim
- 显式 `input: "y\n"` 兜底 wrangler 默认交互 `Ok to proceed?` 在非 TTY 环境下秒退
- runStep 增强 `status === null` 与 signal 诊断

### #55 fix(auth): 适配 Bitwarden / 1Password 密码管理器自动填充
**修管理员密码框无法触发密码管理器自动填充**

- 根因：Bitwarden / 1Password 启发式需 username + password 双字段才识别为登录表单
- 修复：W3C 推荐 hidden username 模式 + name/id/aria-label/autoComplete 完整 metadata
- 影响两处：admin-gate.tsx 弹窗 + pages/admin/login.tsx 全屏登录页

## 风险评估

- 后端无改动，无数据库迁移
- 前端只新增 hidden input + 表单 metadata，零视觉变化
- 部署脚本改动仅影响迁移步骤命令行，CLI 已本机验证

## 合并后动作

1. 自动 release-please 生成 v2.3.1 Release（30s 内）
2. 推送通知 XBro 重新拉 main 分支跑 `npm run deploy:cloudflare`