### PR TITLE
chore(deploy): warn Windows users about autocrlf and OneDrive paths

### DIFF
--- a/scripts/deploy-cloudflare.mjs
+++ b/scripts/deploy-cloudflare.mjs
@@ -140,6 +140,29 @@ function checkPrerequisites() {
     console.error("\n详见 README 「☁️ 部署 → 预检清单」。");
     process.exit(1);
   }
+
+  // Windows 环境卫生提示（非阻断，仅警告）
+  if (IS_WIN) {
+    const autocrlfProbe = spawnSync("git", ["config", "--get", "core.autocrlf"], {
+      cwd: projectRoot,
+      encoding: "utf8",
+      shell: SHELL,
+    });
+    const autocrlf = (autocrlfProbe.stdout || "").trim();
+    if (autocrlf === "true") {
+      console.warn(
+        "[warn] git core.autocrlf=true 检测到——可能把 wrangler.toml/*.mjs 改成 CRLF，wrangler 解析 toml 偶发报错。",
+      );
+      console.warn("[hint] 建议执行：git config --global core.autocrlf input 后重新 clone 仓库。");
+    }
+    const cwdLower = projectRoot.toLowerCase();
+    if (cwdLower.includes("\\onedrive\\") || cwdLower.includes("/onedrive/")) {
+      console.warn(
+        "[warn] 仓库位于 OneDrive 同步目录——OneDrive 实时同步会与 Node fs.watch 抢锁，构建偶发卡死。",
+      );
+      console.warn("[hint] 建议把仓库迁移到 C:\\dev\\Monolith 等独立本地目录后重试。");
+    }
+  }
 }
 
 function detectWorkersUrl(output) {

--- a/scripts/deploy-cloudflare.mjs
+++ b/scripts/deploy-cloudflare.mjs
@@ -155,8 +155,10 @@ function checkPrerequisites() {
       );
       console.warn("[hint] 建议执行：git config --global core.autocrlf input 后重新 clone 仓库。");
     }
-    const cwdLower = projectRoot.toLowerCase();
-    if (cwdLower.includes("\\onedrive\\") || cwdLower.includes("/onedrive/")) {
+    // 覆盖个人版 (OneDrive)、企业版 (OneDrive - Contoso)、历史变体 (OneDriveCommercial / OneDrive-Personal)
+    // 必须以路径分隔符或路径根开始，紧跟 onedrive，后接空格/连字符/分隔符/词尾，或紧跟字母（Commercial 等）
+    const oneDrivePattern = /(?:^|[\\/])onedrive(?:[\s\-\\/]|[A-Za-z]|$)/i;
+    if (oneDrivePattern.test(projectRoot)) {
       console.warn(
         "[warn] 仓库位于 OneDrive 同步目录——OneDrive 实时同步会与 Node fs.watch 抢锁，构建偶发卡死。",
       );


### PR DESCRIPTION
## 变更动机

承接 H005 端到端部署测试（Wiki Deployment.md 全流程演练通过），把推演到的 Win/Mac 平台差异沉淀到代码与文档。

## 改动内容

`scripts/deploy-cloudflare.mjs`：在 `checkPrerequisites()` 末尾追加**仅 Windows 触发**的两条非阻断卫生检查：

| ID | 检测项 | 触发条件 | 修复 hint |
|---|---|---|---|
| W4 | `git core.autocrlf=true` | clone 时把 wrangler.toml/*.mjs 改成 CRLF，wrangler 解析 toml 偶发报错 | 建议 `git config --global core.autocrlf input` 后重新 clone |
| W5 | OneDrive 同步路径 | OneDrive 实时同步与 Node fs.watch 抢锁，构建偶发卡死 | 建议把仓库迁移到 `C:\\dev\\Monolith` 等独立本地目录 |

## 测试

- ✅ Linux H005 实跑 `--skip-migrate --skip-server --skip-client` 路径，新增分支被 `IS_WIN` 卫闸完全隔离，无任何输出变化
- ✅ `node --check` 语法通过
- ✅ Linux/macOS 用户**零副作用**（卫闸 `if (IS_WIN)` 完全屏蔽）
- ⏳ 等 Win11 用户真实环境验证 hint 触发条件

## 不变更

- 现有部署成功路径完全保持原样
- 不阻断任何环境的部署执行（仅 console.warn）

## 关联

- 完整 Win/Mac 部署链路推演见 `.trae/memory/11-pitfalls-2.md`「跨平台部署链路差异速查」（gitignore，不入仓）
- Wiki `Deployment.md` 同步增补 Win11 前置卫生章节（直推 Wiki repo，不走 PR）