### PR TITLE
chore(release): v2.3.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "workspaces": [
     "client",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-server",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 版本概要

v2.3.2 patch release，跨平台部署链路加固，源自 H005 Linux 端到端实测 + Win/Mac 平台推演。

## 包含内容

### #58 chore(deploy): warn Windows users about autocrlf and OneDrive paths

**为 Windows 11 用户补环境卫生预检 + 修正 Wiki 登录端点描述**

- \`scripts/deploy-cloudflare.mjs\` 在 \`checkPrerequisites()\` 末尾追加 \`IS_WIN\` 卫闸下的非阻断卫生检查：
  - **W4**：检测 \`git core.autocrlf=true\` 给出修复 hint（避免 \`wrangler.toml\` 被改成 CRLF 引发 toml 解析怪错）
  - **W5**：正则 \`(?:^|[\\\\/])onedrive(?:[\\s\\-\\\\/]|[A-Za-z]|\$)/i\` 匹配 OneDrive 同步目录
    - 覆盖个人版 \`OneDrive\` / 企业版 \`OneDrive - Contoso\` / 历史变体 \`OneDriveCommercial\` / \`OneDrive-Personal\`
    - 不误匹配 \`onedrive_user\` / \`my-onedrive-backup\`
    - **9/9 单测全过**
- Wiki \`Deployment.md\` 同步增补：
  - 步骤 2 新增「Windows 11 前置卫生」章节（autocrlf / OneDrive / Defender 三条）
  - 步骤 2 新增「macOS 注意点」（Apple Silicon 不要 brew install wrangler / Gatekeeper）
  - 步骤 5 验证段补 \`/api/auth/login\` curl 示例（实测发现首次部署用户易误用 \`/api/admin/login\` 报 401）

## 验证

- ✅ Linux 实测 \`--skip-*\` 路径无任何输出变化（IS_WIN 卫闸隔离）
- ✅ \`node --check scripts/deploy-cloudflare.mjs\` 语法 OK
- ✅ OneDrive 正则 9/9 单测全过
- ✅ PR #58 全部 CI 绿（Lint / Typecheck / Build / CodeQL / ESLint 安全扫描 / Analyze）
- ✅ CodeRabbit review thread 已 resolved

## 合并后

- 自动 release workflow 会基于 \`v2.3.2\` 标签生成对应 GitHub Release
- 不需要再手动 \`gh release create\`（铁律 20）