### PR TITLE
fix: address deployment login and admin injection issues

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -52,6 +52,10 @@ function injectHtml(container: HTMLElement, html: string) {
   });
 }
 
+function removeCustomInjection() {
+  document.querySelectorAll("[data-monolith-custom-injection=\"true\"]").forEach((node) => node.remove());
+}
+
 function matchesPathPrefix(pathname: string, prefix: string) {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
@@ -74,22 +78,35 @@ export function App() {
 
   // 注入自定义 header/footer 代码（需 Cookie 同意后加载第三方脚本）
   useEffect(() => {
+    removeCustomInjection();
+    if (isAdminRoot) return undefined;
+
+    let cancelled = false;
+    let cleanupConsentListener: (() => void) | undefined;
+
     fetch("/api/settings/public")
       .then((r) => r.json())
       .then((s) => {
+        if (cancelled) return;
         const hasThirdParty = (s.custom_header && /<script/i.test(s.custom_header))
           || (s.custom_footer && /<script/i.test(s.custom_footer));
 
         const inject = () => {
+          if (cancelled) return;
+          removeCustomInjection();
           if (s.custom_header) {
             const container = document.createElement("div");
             container.id = "monolith-custom-header";
             injectHtml(container, s.custom_header);
-            Array.from(container.childNodes).forEach((n) => document.head.appendChild(n));
+            Array.from(container.childNodes).forEach((n) => {
+              if (n instanceof HTMLElement) n.dataset.monolithCustomInjection = "true";
+              document.head.appendChild(n);
+            });
           }
           if (s.custom_footer) {
             const container = document.createElement("div");
             container.id = "monolith-custom-footer";
+            container.dataset.monolithCustomInjection = "true";
             injectHtml(container, s.custom_footer);
             document.body.appendChild(container);
           }
@@ -102,10 +119,16 @@ export function App() {
           inject();
         } else {
           window.addEventListener("cookie-consent-accepted", inject, { once: true });
+          cleanupConsentListener = () => window.removeEventListener("cookie-consent-accepted", inject);
         }
       })
       .catch(() => {});
-  }, []);
+    return () => {
+      cancelled = true;
+      cleanupConsentListener?.();
+      removeCustomInjection();
+    };
+  }, [isAdminRoot]);
 
   return (
     <>

--- a/scripts/deploy-cloudflare.mjs
+++ b/scripts/deploy-cloudflare.mjs
@@ -70,7 +70,7 @@ function failStep(title, command, result) {
   if (result.error) {
     console.error(`\n[error] 步骤 "${title}" 启动失败：${result.error.message}`);
     if (result.error.code === "ENOENT") {
-      console.error(`[hint] 找不到命令 "${command}"。请确认已安装 Node.js (>=20) 与 npm，并将其加入 PATH。`);
+      console.error(`[hint] 找不到命令 "${command}"。请确认已安装 Node.js (>=22) 与 npm，并将其加入 PATH。`);
       console.error(`[hint] Windows 用户请通过官网安装包或 nvm-windows 安装；macOS/Linux 推荐用 fnm/nvm。`);
     }
     process.exit(1);
@@ -105,7 +105,7 @@ function runCapture(title, command, args) {
   return `${result.stdout || ""}\n${result.stderr || ""}`;
 }
 
-function checkPrerequisites() {
+function checkPrerequisites(options) {
   const errors = [];
   // wrangler 登录态检测：API_TOKEN 或本机 oauth 二选一
   const tokenPresent = !!process.env.CLOUDFLARE_API_TOKEN;
@@ -129,6 +129,18 @@ function checkPrerequisites() {
   if (!process.env.CLOUDFLARE_ACCOUNT_ID && tokenPresent) {
     errors.push(
       "已设置 CLOUDFLARE_API_TOKEN 但未设置 CLOUDFLARE_ACCOUNT_ID。Token 模式下必须显式提供账户 ID。",
+    );
+  }
+
+  if (!options.skipServer && !process.env.ADMIN_PASSWORD) {
+    errors.push(
+      "未设置 ADMIN_PASSWORD。请先在当前 shell 中设置后台登录密码，例如：`export ADMIN_PASSWORD='换成强密码'`。",
+    );
+  }
+
+  if (!options.skipServer && !process.env.JWT_SECRET) {
+    errors.push(
+      "未设置 JWT_SECRET。请先生成并设置 JWT 签名密钥，例如：`export JWT_SECRET=\"$(openssl rand -base64 32)\"`。",
     );
   }
 
@@ -212,7 +224,7 @@ function printPrerequisiteHints() {
 
 const options = parseArgs(process.argv.slice(2));
 printPrerequisiteHints();
-checkPrerequisites();
+checkPrerequisites(options);
 
 if (!options.skipMigrate) {
   // 绕过 npm workspace shim 直接调 wrangler，避免 Windows 双层 shell 转发吞 stdin
@@ -231,16 +243,13 @@ if (!options.skipMigrate) {
 }
 
 if (!options.skipServer) {
-  if (process.env.ADMIN_PASSWORD) {
-    runStep("写入 Backend 的 ADMIN_PASSWORD", "npx", [
-      "wrangler", "secret", "put", "ADMIN_PASSWORD", "--name", "monolith-server"
-    ], { input: `${process.env.ADMIN_PASSWORD}\n`, cwd: `${projectRoot}/server` });
-  }
-  if (process.env.JWT_SECRET) {
-    runStep("写入 Backend 的 JWT_SECRET", "npx", [
-      "wrangler", "secret", "put", "JWT_SECRET", "--name", "monolith-server"
-    ], { input: `${process.env.JWT_SECRET}\n`, cwd: `${projectRoot}/server` });
-  }
+  runStep("写入 Backend 的 ADMIN_PASSWORD", "npx", [
+    "wrangler", "secret", "put", "ADMIN_PASSWORD", "--name", "monolith-server"
+  ], { input: `${process.env.ADMIN_PASSWORD}\n`, cwd: `${projectRoot}/server` });
+
+  runStep("写入 Backend 的 JWT_SECRET", "npx", [
+    "wrangler", "secret", "put", "JWT_SECRET", "--name", "monolith-server"
+  ], { input: `${process.env.JWT_SECRET}\n`, cwd: `${projectRoot}/server` });
 
   const deployOutput = runCapture("部署 Cloudflare Workers 后端", "npm", ["run", "deploy:server"]);
   if (!options.apiBase) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -732,11 +732,26 @@ function pruneLoginAttempts(now: number) {
   }
 }
 
+function getMissingAuthSecrets(env: Partial<Bindings>) {
+  return [
+    ["ADMIN_PASSWORD", env.ADMIN_PASSWORD],
+    ["JWT_SECRET", env.JWT_SECRET],
+  ].filter(([, value]) => typeof value !== "string" || value.length === 0).map(([key]) => key);
+}
+
 /* ── 认证 API ──────────────────────────────── */
 
 // 登录
 app.post("/api/auth/login", async (c) => {
   c.header("Cache-Control", "no-store");
+  const missingSecrets = getMissingAuthSecrets(c.env);
+  if (missingSecrets.length > 0) {
+    return c.json({
+      error: "后台认证未完成配置，请在 Cloudflare Workers 中配置 ADMIN_PASSWORD 和 JWT_SECRET 后重新部署。",
+      missing: missingSecrets,
+    }, 503);
+  }
+
   const ip = getClientIp(c);
 
   // 速率限制


### PR DESCRIPTION
## Summary\n- stop rendering custom header/footer injection on /admin routes and clean up injected DOM when entering admin\n- fail Cloudflare deploy preflight when ADMIN_PASSWORD or JWT_SECRET is missing, then always write both secrets during backend deploy\n- return a clear 503 setup error from /api/auth/login when backend auth secrets are missing instead of reporting an incorrect password\n\n## Issues\n- Fixes #103\n- Partially addresses #87 by isolating custom injection from /admin; the remaining feature requests stay open for separate work.\n\n## Validation\n- npm run lint\n- npm run check\n- npm run build\n- node --check scripts/deploy-cloudflare.mjs