### PR TITLE
fix(ui): polish issue 87 site chrome behavior

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -56,6 +56,26 @@ function removeCustomInjection() {
   document.querySelectorAll("[data-monolith-custom-injection=\"true\"]").forEach((node) => node.remove());
 }
 
+function syncDocumentBrand(settings: { site_title?: string; site_description?: string; site_icon?: string }) {
+  const siteTitle = settings.site_title?.trim();
+  const description = settings.site_description?.trim();
+  const icon = settings.site_icon?.trim();
+
+  if (siteTitle && document.title.startsWith("Monolith")) {
+    document.title = description ? `${siteTitle} — ${description}` : siteTitle;
+  }
+
+  if (icon) {
+    let link = document.querySelector('link[rel="icon"]') as HTMLLinkElement | null;
+    if (!link) {
+      link = document.createElement("link");
+      link.rel = "icon";
+      document.head.appendChild(link);
+    }
+    link.href = icon;
+  }
+}
+
 function matchesPathPrefix(pathname: string, prefix: string) {
   return pathname === prefix || pathname.startsWith(`${prefix}/`);
 }
@@ -88,6 +108,7 @@ export function App() {
       .then((r) => r.json())
       .then((s) => {
         if (cancelled) return;
+        syncDocumentBrand(s);
         const hasThirdParty = (s.custom_header && /<script/i.test(s.custom_header))
           || (s.custom_footer && /<script/i.test(s.custom_footer));
 

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -20,9 +20,19 @@ export function Navbar() {
   const [open, setOpen] = useState(false);
   const [gateOpen, setGateOpen] = useState(false);
   const [navPages, setNavPages] = useState<NavPage[]>([]);
+  const [brand, setBrand] = useState({ title: "Monolith", icon: "" });
 
   useEffect(() => {
     fetchNavPages().then(setNavPages);
+    fetch("/api/settings/public")
+      .then((r) => r.json())
+      .then((settings: { site_title?: string; site_icon?: string }) => {
+        setBrand({
+          title: settings.site_title?.trim() || "Monolith",
+          icon: settings.site_icon?.trim() || "",
+        });
+      })
+      .catch(() => {});
   }, []);
 
   const navLinks = useMemo(
@@ -62,11 +72,19 @@ export function Navbar() {
             className="group flex items-center gap-[10px] select-none animate-slide-in-left"
             onDoubleClick={handleLogoDoubleClick}
           >
-            <div className="relative flex h-[32px] w-[20px] items-center justify-center">
-              <div className="absolute inset-0 rounded-[3px] bg-gradient-to-b from-foreground/90 to-foreground/44 transition-all duration-300 group-hover:from-foreground group-hover:to-foreground/62" />
+            <div className="relative flex h-[32px] w-[32px] shrink-0 items-center justify-center">
+              {brand.icon ? (
+                <img
+                  src={brand.icon}
+                  alt=""
+                  className="h-[28px] w-[28px] rounded-md object-cover transition-transform duration-300 group-hover:-translate-y-[2px]"
+                />
+              ) : (
+                <div className="absolute inset-0 rounded-[3px] bg-gradient-to-b from-foreground/90 to-foreground/44 transition-all duration-300 group-hover:from-foreground group-hover:to-foreground/62" />
+              )}
             </div>
-            <span className="text-[18px] font-semibold tracking-[-0.03em] text-foreground">
-              Monolith
+            <span className="max-w-[180px] truncate text-[18px] font-semibold tracking-[-0.03em] text-foreground sm:max-w-[240px]">
+              {brand.title}
             </span>
           </Link>
 

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -11,6 +11,7 @@ type Settings = {
   hero_description: string;
   hero_actions: string;
   hero_topics: string;
+  site_icon: string;
   site_og_image: string;
   author_name: string;
   author_title: string;
@@ -43,6 +44,7 @@ const defaultSettings: Settings = {
     { title: "阅读体验", desc: "让长文、代码与目录保持同一节奏" },
     { title: "边缘部署", desc: "Workers / D1 / R2 的真实工程路径" },
   ]),
+  site_icon: "",
   site_og_image: "",
   author_name: "Monolith",
   author_title: "独立开发者",
@@ -443,6 +445,7 @@ export function AdminSettings() {
                   <SettingField label="站点标题" value={settings.site_title} onChange={(v) => updateSetting("site_title", v)} placeholder="Monolith" hint="用于首页 H1、SEO site_name 和 RSS 标题。" />
                   <SettingField label="站点描述" value={settings.site_description} onChange={(v) => updateSetting("site_description", v)} placeholder="一句话描述你的博客（建议 80-160 字）" multiline hint={`${settings.site_description.length} 个字符，首页 Hero 未单独设置时也会使用它。`} />
                   <SettingField label="首页标语" value={settings.site_tagline} onChange={(v) => updateSetting("site_tagline", v)} placeholder="显示在首页首屏小标题区域" hint="作为首页副标题的回退值，适合写短句而不是长段落。" />
+                  <SettingField label="站点图标 URL" value={settings.site_icon} onChange={(v) => updateSetting("site_icon", v)} placeholder="https://example.com/favicon.png" mono hint="用于浏览器 favicon 和左上角后台暗门入口，留空则使用默认图标。" />
                   <SettingField label="社交分享图 URL" value={settings.site_og_image} onChange={(v) => updateSetting("site_og_image", v)} placeholder="https://example.com/og-image.png" mono hint="用于首页 Open Graph / Twitter Card，留空则使用默认 og-default.png。" />
                   <SettingField label="页脚文本" value={settings.footer_text} onChange={(v) => updateSetting("footer_text", v)} placeholder="© 2026 ..." hint="显示在全站页脚，支持纯文本。" />
                 </div>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -18,6 +18,7 @@ type PublicSettings = {
   hero_description: string;
   hero_actions: string;
   hero_topics: string;
+  site_icon: string;
   site_og_image: string;
   author_name: string;
   author_title: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -32,7 +32,12 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
+        navigateFallbackDenylist: [/^\/sitemap\.xml$/i, /^\/robots\.txt$/i, /^\/rss\.xml$/i],
         runtimeCaching: [
+          {
+            urlPattern: /\/(?:sitemap\.xml|robots\.txt|rss\.xml)$/i,
+            handler: "NetworkOnly",
+          },
           {
             urlPattern: /\/cdn\/.*/i,
             handler: "CacheFirst",
@@ -66,6 +71,8 @@ export default defineConfig({
       "/api": "http://localhost:8787",
       "/cdn": "http://localhost:8787",
       "/rss.xml": "http://localhost:8787",
+      "/sitemap.xml": "http://localhost:8787",
+      "/robots.txt": "http://localhost:8787",
     },
   },
   build: {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -562,6 +562,7 @@ app.get("/api/settings/public", async (c) => {
     hero_description: all.hero_description || "",
     hero_actions: all.hero_actions || "",
     hero_topics: all.hero_topics || "",
+    site_icon: all.site_icon || "",
     site_og_image: all.site_og_image || "",
     footer_text: all.footer_text || "",
     author_name: all.author_name || "Monolith",


### PR DESCRIPTION
## Summary\n- keep sitemap.xml, robots.txt, and rss.xml out of PWA navigation fallback/cache handling\n- add a configurable site icon setting and expose it through public settings\n- sync the header brand title/icon and favicon from site settings earlier on public routes\n\n## Issue #87 coverage\n- Continues #87 after the admin injection fix in #106\n- Addresses the PWA sitemap cache report\n- Addresses the site title/favicon/header brand sync reports\n- Existing post update behavior already preserves createdAt; public timelines render createdAt, while updatedAt remains a separate modified timestamp\n- Friend-link application and guestbook are larger feature modules and should stay separate from this polish PR\n\n## Validation\n- npm run lint\n- npm run check\n- npm run build