### PR TITLE
fix(server): RSS SITE_ORIGIN + sitemap /page path

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,7 +27,7 @@ type Bindings = {
   AUTO_SCHEMA_MIGRATION?: string;
   STORAGE_PROVIDER?: string;
   WEBHOOK_URLS?: string; // 逗号分隔的 Webhook 目标地址
-  SITE_ORIGIN?: string; // 对外公开域名（如 https://monolith-client.pages.dev），用于 sitemap/robots
+  SITE_ORIGIN?: string; // 对外公开域名（如 https://monolith-client.pages.dev），用于 sitemap/robots/RSS
   CLOUDFLARE_ACCOUNT_ID?: string; // AE GraphQL 查询用
   CLOUDFLARE_API_TOKEN?: string; // AE GraphQL 查询用（需要 Account Analytics:Read 权限）
   ANALYTICS_WEBSITE_WHITELIST?: string; // 站点白名单，格式: domain1|domain2 (空=放行所有)
@@ -605,7 +605,9 @@ app.get("/rss.xml", async (c) => {
   const settings = await db.getSettings();
   const siteTitle = settings.site_title || "Monolith";
   const siteDesc = settings.site_description || "";
-  const siteUrl = new URL(c.req.url).origin;
+  // Prefer public origin: /rss.xml is reverse-proxied via Pages Functions, so
+  // request origin may be *.workers.dev. Keep consistent with sitemap/robots.
+  const siteUrl = c.env.SITE_ORIGIN || new URL(c.req.url).origin;
 
   // 获取最新 20 篇文章
   const allPosts = await db.getRecentPublishedPosts(20);
@@ -676,10 +678,10 @@ app.get("/sitemap.xml", async (c) => {
   </url>`);
   }
 
-  // 独立页面
+  // 独立页面 — frontend route is /page/:slug (see client/src/app.tsx)
   for (const page of allPages) {
     urls.push(`  <url>
-    <loc>${escXml(siteUrl)}/pages/${escXml(page.slug)}</loc>
+    <loc>${escXml(siteUrl)}/page/${escXml(page.slug)}</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>`);


### PR DESCRIPTION
## Summary
Two small SEO correctness fixes in `server/src/index.ts`. Verified still present on `one-ea/Monolith@main` before opening this PR.

### 1. RSS should prefer `SITE_ORIGIN`
**Bug:** `/rss.xml` builds channel/item links with `new URL(c.req.url).origin` only.

In the recommended Cloudflare setup, Pages Functions reverse-proxy `/rss.xml` to the Worker (`client/functions/rss.xml.ts`). The Worker then sees a `*.workers.dev` request origin, so the feed emits workers.dev absolute links instead of the public site domain.

**Why this is real upstream:** `sitemap.xml` and `robots.txt` already use `c.env.SITE_ORIGIN || requestOrigin`. RSS was left on request origin only. The env comment even documents `SITE_ORIGIN` for sitemap/robots, but not RSS.

**Fix:** use the same origin resolution as sitemap/robots:
```ts
const siteUrl = c.env.SITE_ORIGIN || new URL(c.req.url).origin;
```

### 2. Sitemap independent pages path is wrong
**Bug:** sitemap writes independent pages as `/pages/:slug`.

**Frontend route is singular `/page/:slug`:**
- `client/src/app.tsx` → `<Route path="/page/:slug" ...>`
- navbar / footer / admin page preview all link to `/page/${slug}`

So sitemap currently advertises URLs that do not match the app router.

**Fix:** emit `/page/:slug`.

## Test plan
- [ ] With `SITE_ORIGIN=https://example.com`, `GET /rss.xml` channel/item `<link>` and `<guid>` use `https://example.com`, not the Worker host
- [ ] Without `SITE_ORIGIN`, RSS still falls back to request origin (previous behavior)
- [ ] `GET /sitemap.xml` independent page entries use `/page/<slug>` (not `/pages/<slug>`)
- [ ] Existing post/archive/home sitemap entries unchanged
- [ ] `robots.txt` behavior unchanged

## Notes
- Single-file change; no client/branding/local customizations included
- Safe fallback retained when `SITE_ORIGIN` is unset
