### PR TITLE
feat(friends): restore moderated friend links

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -14,6 +14,7 @@ const HomePage = lazy(() => import("@/pages/home").then((m) => ({ default: m.Hom
 const PostPage = lazy(() => import("@/pages/post").then((m) => ({ default: m.PostPage })));
 const ArchivePage = lazy(() => import("@/pages/archive").then((m) => ({ default: m.ArchivePage })));
 const AboutPage = lazy(() => import("@/pages/about").then((m) => ({ default: m.AboutPage })));
+const FriendsPage = lazy(() => import("@/pages/friends").then((m) => ({ default: m.FriendsPage })));
 const AdminLogin = lazy(() => import("@/pages/admin/login").then((m) => ({ default: m.AdminLogin })));
 const AdminDashboard = lazy(() => import("@/pages/admin/dashboard").then((m) => ({ default: m.AdminDashboard })));
 const AdminEditor = lazy(() => import("@/pages/admin/editor").then((m) => ({ default: m.AdminEditor })));
@@ -21,6 +22,7 @@ const AdminSettings = lazy(() => import("@/pages/admin/settings").then((m) => ({
 const AdminBackup = lazy(() => import("@/pages/admin/backup").then((m) => ({ default: m.AdminBackup })));
 const AdminPages = lazy(() => import("@/pages/admin/pages").then((m) => ({ default: m.AdminPages })));
 const AdminComments = lazy(() => import("@/pages/admin/comments").then((m) => ({ default: m.AdminComments })));
+const AdminFriends = lazy(() => import("@/pages/admin/friends").then((m) => ({ default: m.AdminFriends })));
 const AdminMedia = lazy(() => import("@/pages/admin/media").then((m) => ({ default: m.AdminMedia })));
 const AdminAnalytics = lazy(() => import("@/pages/admin/analytics").then((m) => ({ default: m.AdminAnalytics })));
 const AdminSeo = lazy(() => import("@/pages/admin/seo").then((m) => ({ default: m.AdminSeo })));
@@ -166,6 +168,7 @@ export function App() {
                 <Route path="/posts/:slug" component={PostPage} />
                 <Route path="/archive" component={ArchivePage} />
                 <Route path="/about" component={AboutPage} />
+                <Route path="/friends" component={FriendsPage} />
                 <Route path="/privacy" component={PrivacyPage} />
                 <Route path="/page/:slug" component={DynamicPage} />
                 <Route>
@@ -215,6 +218,7 @@ export function App() {
                 <Route path="/admin/backup"><AdminBackup /></Route>
                 <Route path="/admin/pages"><AdminPages /></Route>
                 <Route path="/admin/comments"><AdminComments /></Route>
+                <Route path="/admin/friends"><AdminFriends /></Route>
                 <Route path="/admin/media"><AdminMedia /></Route>
                 <Route path="/admin/analytics"><AdminAnalytics /></Route>
                 <Route path="/admin/seo"><AdminSeo /></Route>

--- a/client/src/components/admin-layout.tsx
+++ b/client/src/components/admin-layout.tsx
@@ -5,6 +5,7 @@ import {
   LayoutDashboard,
   StickyNote,
   MessageCircle,
+  Link2,
   ImageIcon,
   BarChart3,
   HardDrive,
@@ -29,6 +30,7 @@ const NAV_GROUPS = [
       { href: "/admin", icon: LayoutDashboard, label: "运营总览" },
       { href: "/admin/pages", icon: StickyNote, label: "页面管理" },
       { href: "/admin/comments", icon: MessageCircle, label: "互动审核" },
+      { href: "/admin/friends", icon: Link2, label: "友链管理" },
     ],
   },
   {

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -12,6 +12,7 @@ import { fetchNavPages, type NavPage } from "@/lib/api";
 const fixedStart = [{ href: "/", label: "首页" }];
 const fixedEnd = [
   { href: "/archive", label: "归档" },
+  { href: "/friends", label: "友链" },
   { href: "/about", label: "关于" },
 ];
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -583,7 +583,7 @@ export async function fetchAdminFriends(): Promise<FriendLink[]> {
   const res = await fetch(`${API_BASE}/api/admin/friends`, {
     headers: authHeaders(),
   });
-  if (!res.ok) throw new Error("获取友链失败");
+  if (!res.ok) throw new Error(await readError(res, "获取友链失败"));
   return res.json();
 }
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -65,6 +65,45 @@ export type Post = PostMeta & {
   seriesOrder: number;
 };
 
+export type FriendLinkStatus = "pending" | "approved" | "rejected";
+export type FriendLinkSource = "manual" | "submission" | "imported";
+
+export type FriendLink = {
+  id: number;
+  name: string;
+  url: string;
+  description: string;
+  avatarUrl: string;
+  ownerName?: string;
+  ownerEmail?: string;
+  status?: FriendLinkStatus;
+  source?: FriendLinkSource;
+  sortOrder: number;
+  createdAt?: string;
+  updatedAt?: string;
+  reviewedAt?: string | null;
+};
+
+export type FriendLinkInput = {
+  name: string;
+  url: string;
+  description?: string;
+  avatarUrl?: string;
+  ownerName?: string;
+  ownerEmail?: string;
+  status?: FriendLinkStatus;
+  sortOrder?: number;
+};
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json() as { error?: string };
+    return body.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 /* ── 公开 API ──────────────────────────────── */
 export async function fetchPosts(): Promise<PostMeta[]> {
   return fetchJsonWithCache<PostMeta[]>("/api/posts", 60_000);
@@ -77,6 +116,20 @@ export async function fetchPost(slug: string): Promise<Post> {
 export async function fetchTags(): Promise<{ id: number; name: string }[]> {
   const res = await fetch(`${API_BASE}/api/tags`);
   if (!res.ok) throw new Error("获取标签失败");
+  return res.json();
+}
+
+export async function fetchFriends(): Promise<FriendLink[]> {
+  return fetchJsonWithCache<FriendLink[]>("/api/friends", 60_000);
+}
+
+export async function applyFriendLink(data: FriendLinkInput): Promise<{ success: boolean }> {
+  const res = await fetch(`${API_BASE}/api/friends/apply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await readError(res, "提交失败"));
   return res.json();
 }
 
@@ -523,6 +576,67 @@ export async function fetchAdminComments(): Promise<AdminComment[]> {
     headers: authHeaders(),
   });
   if (!res.ok) throw new Error("获取评论失败");
+  return res.json();
+}
+
+export async function fetchAdminFriends(): Promise<FriendLink[]> {
+  const res = await fetch(`${API_BASE}/api/admin/friends`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error("获取友链失败");
+  return res.json();
+}
+
+export async function createAdminFriend(data: FriendLinkInput): Promise<FriendLink> {
+  const res = await fetch(`${API_BASE}/api/admin/friends`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await readError(res, "创建友链失败"));
+  return res.json();
+}
+
+export async function updateAdminFriend(id: number, data: Partial<FriendLinkInput>): Promise<FriendLink> {
+  const res = await fetch(`${API_BASE}/api/admin/friends/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await readError(res, "更新友链失败"));
+  return res.json();
+}
+
+export async function approveFriend(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/admin/friends/${id}/approve`, {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(await readError(res, "审核失败"));
+}
+
+export async function rejectFriend(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/admin/friends/${id}/reject`, {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(await readError(res, "拒绝失败"));
+}
+
+export async function deleteFriend(id: number): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/admin/friends/${id}`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(await readError(res, "删除失败"));
+}
+
+export async function importSocialFriendLinks(): Promise<{ imported: number }> {
+  const res = await fetch(`${API_BASE}/api/admin/friends/import-social-links`, {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(await readError(res, "导入失败"));
   return res.json();
 }
 

--- a/client/src/pages/admin/friends.tsx
+++ b/client/src/pages/admin/friends.tsx
@@ -1,0 +1,381 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import {
+  Check,
+  Clock,
+  Download,
+  Edit3,
+  ExternalLink,
+  Link2,
+  Plus,
+  Save,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  approveFriend,
+  createAdminFriend,
+  deleteFriend,
+  fetchAdminFriends,
+  importSocialFriendLinks,
+  rejectFriend,
+  updateAdminFriend,
+  type FriendLink,
+  type FriendLinkStatus,
+} from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+
+type FilterType = "all" | FriendLinkStatus;
+type FormState = {
+  id: number | null;
+  name: string;
+  url: string;
+  description: string;
+  avatarUrl: string;
+  ownerName: string;
+  ownerEmail: string;
+  status: FriendLinkStatus;
+  sortOrder: number;
+};
+
+const EMPTY_FORM: FormState = {
+  id: null,
+  name: "",
+  url: "",
+  description: "",
+  avatarUrl: "",
+  ownerName: "",
+  ownerEmail: "",
+  status: "approved",
+  sortOrder: 0,
+};
+
+const STATUS_META: Record<FriendLinkStatus, { label: string; className: string }> = {
+  pending: { label: "待审核", className: "border-amber-400/20 text-amber-500" },
+  approved: { label: "已通过", className: "border-emerald-400/20 text-emerald-500" },
+  rejected: { label: "已拒绝", className: "border-red-400/20 text-red-500" },
+};
+
+const inputClass = "h-[36px] w-full rounded-md border border-border/25 bg-background/30 px-[10px] text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/30 focus:border-foreground/20";
+
+function formatDate(value?: string | null) {
+  if (!value) return "未记录";
+  return new Date(value).toLocaleDateString("zh-CN", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function toForm(link: FriendLink): FormState {
+  return {
+    id: link.id,
+    name: link.name,
+    url: link.url,
+    description: link.description || "",
+    avatarUrl: link.avatarUrl || "",
+    ownerName: link.ownerName || "",
+    ownerEmail: link.ownerEmail || "",
+    status: link.status || "pending",
+    sortOrder: link.sortOrder || 0,
+  };
+}
+
+export function AdminFriends() {
+  const [links, setLinks] = useState<FriendLink[]>([]);
+  const [filter, setFilter] = useState<FilterType>("all");
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [processing, setProcessing] = useState<number | null>(null);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const loadLinks = async () => {
+    setLoading(true);
+    try {
+      setLinks(await fetchAdminFriends());
+      setMessage(null);
+    } catch {
+      setLinks([]);
+      setMessage({ type: "error", text: "友链列表加载失败" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    document.title = "友链管理 | Monolith";
+    loadLinks();
+  }, []);
+
+  const counts = useMemo(() => ({
+    all: links.length,
+    pending: links.filter((link) => link.status === "pending").length,
+    approved: links.filter((link) => link.status === "approved").length,
+    rejected: links.filter((link) => link.status === "rejected").length,
+  }), [links]);
+
+  const filteredLinks = useMemo(() => {
+    const list = filter === "all" ? links : links.filter((link) => link.status === filter);
+    return [...list].sort((a, b) => a.sortOrder - b.sortOrder || b.id - a.id);
+  }, [filter, links]);
+
+  const updateField = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+  };
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!form.name.trim() || !form.url.trim()) {
+      setMessage({ type: "error", text: "名称和 URL 不能为空" });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const payload = {
+        name: form.name,
+        url: form.url,
+        description: form.description,
+        avatarUrl: form.avatarUrl,
+        ownerName: form.ownerName,
+        ownerEmail: form.ownerEmail,
+        status: form.status,
+        sortOrder: form.sortOrder,
+      };
+      const saved = form.id
+        ? await updateAdminFriend(form.id, payload)
+        : await createAdminFriend(payload);
+      setLinks((prev) => {
+        const exists = prev.some((link) => link.id === saved.id);
+        return exists ? prev.map((link) => (link.id === saved.id ? saved : link)) : [saved, ...prev];
+      });
+      setForm(toForm(saved));
+      setMessage({ type: "success", text: form.id ? "友链已更新" : "友链已创建" });
+    } catch (error) {
+      setMessage({ type: "error", text: error instanceof Error ? error.message : "保存失败" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const runAction = async (id: number, action: "approve" | "reject" | "delete") => {
+    if (action === "delete" && !confirm("确定删除这条友链？此操作不可撤销。")) return;
+    setProcessing(id);
+    try {
+      if (action === "approve") await approveFriend(id);
+      if (action === "reject") await rejectFriend(id);
+      if (action === "delete") await deleteFriend(id);
+      if (action === "delete") {
+        setLinks((prev) => prev.filter((link) => link.id !== id));
+        if (form.id === id) resetForm();
+      } else {
+        setLinks((prev) => prev.map((link) => (
+          link.id === id
+            ? { ...link, status: action === "approve" ? "approved" : "rejected", reviewedAt: new Date().toISOString() }
+            : link
+        )));
+      }
+      setMessage({ type: "success", text: action === "approve" ? "已通过" : action === "reject" ? "已拒绝" : "已删除" });
+    } catch (error) {
+      setMessage({ type: "error", text: error instanceof Error ? error.message : "操作失败" });
+    } finally {
+      setProcessing(null);
+    }
+  };
+
+  const importLegacy = async () => {
+    setSaving(true);
+    try {
+      const result = await importSocialFriendLinks();
+      await loadLinks();
+      setMessage({ type: "success", text: `已导入 ${result.imported} 条旧社交链接` });
+    } catch (error) {
+      setMessage({ type: "error", text: error instanceof Error ? error.message : "导入失败" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const filterButtons: { key: FilterType; label: string; icon: typeof Link2 }[] = [
+    { key: "all", label: "全部", icon: Link2 },
+    { key: "pending", label: "待审核", icon: Clock },
+    { key: "approved", label: "已通过", icon: Check },
+    { key: "rejected", label: "已拒绝", icon: X },
+  ];
+
+  return (
+    <div className="mx-auto w-full max-w-[1120px] py-[32px]">
+      <div className="mb-[24px] flex flex-col gap-[12px] sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-[24px] font-semibold tracking-[-0.02em]">友链管理</h1>
+          <p className="mt-[4px] text-[13px] text-muted-foreground/40">审核申请、维护排序，并兼容旧社交链接</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-[8px]">
+          {message && (
+            <span className={`rounded-md px-[10px] py-[6px] text-[12px] ${message.type === "success" ? "bg-emerald-500/10 text-emerald-500" : "bg-red-500/10 text-red-500"}`}>
+              {message.text}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={importLegacy}
+            disabled={saving}
+            className="inline-flex h-[34px] items-center gap-[6px] rounded-md border border-border/25 px-[12px] text-[12px] text-muted-foreground/70 transition-colors hover:bg-muted/40 hover:text-foreground disabled:opacity-50"
+          >
+            <Download className="h-[13px] w-[13px]" />
+            导入旧链接
+          </button>
+          <button
+            type="button"
+            onClick={resetForm}
+            className="inline-flex h-[34px] items-center gap-[6px] rounded-md bg-foreground px-[12px] text-[12px] font-medium text-background transition-opacity hover:opacity-90"
+          >
+            <Plus className="h-[13px] w-[13px]" />
+            新建
+          </button>
+        </div>
+      </div>
+
+      <div className="mb-[18px] grid grid-cols-2 gap-[8px] md:grid-cols-4">
+        {filterButtons.map((item) => {
+          const Icon = item.icon;
+          const active = filter === item.key;
+          return (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => setFilter(item.key)}
+              className={`rounded-md border p-[14px] text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring ${active ? "border-foreground/20 bg-card/30" : "border-border/25 bg-card/10 hover:bg-card/20"}`}
+            >
+              <div className="flex items-center gap-[8px]">
+                <span className="flex h-[30px] w-[30px] items-center justify-center rounded-md bg-foreground/[0.06]">
+                  <Icon className="h-[13px] w-[13px] text-muted-foreground/70" />
+                </span>
+                <span>
+                  <span className="block text-[18px] font-semibold leading-none">{counts[item.key]}</span>
+                  <span className="mt-[2px] block text-[11px] text-muted-foreground/42">{item.label}</span>
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-[16px] lg:grid-cols-[1fr_360px]">
+        <section className="rounded-md border border-border/25">
+          <div className="flex items-center justify-between border-b border-border/15 px-[14px] py-[10px]">
+            <h2 className="text-[12px] font-medium text-muted-foreground/50">友链列表</h2>
+            <span className="text-[11px] text-muted-foreground/30">{filteredLinks.length} 条</span>
+          </div>
+          {loading ? (
+            <div className="space-y-[6px] p-[14px]">
+              {[1, 2, 3].map((item) => <div key={item} className="h-[74px] animate-pulse rounded-md bg-card/15" />)}
+            </div>
+          ) : filteredLinks.length === 0 ? (
+            <div className="py-[52px] text-center">
+              <Link2 className="mx-auto mb-[10px] h-[20px] w-[20px] text-muted-foreground/20" />
+              <p className="text-[13px] text-muted-foreground/45">当前筛选下没有友链</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-border/12">
+              {filteredLinks.map((link) => {
+                const status = link.status || "pending";
+                return (
+                  <article key={link.id} className="group px-[14px] py-[12px] transition-colors hover:bg-card/10">
+                    <div className="flex flex-col gap-[10px] md:flex-row md:items-start">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-[8px]">
+                          <h3 className="max-w-[260px] truncate text-[14px] font-medium text-foreground">{link.name}</h3>
+                          <Badge variant="outline" className={`h-[18px] rounded-[3px] px-[6px] text-[10px] font-normal ${STATUS_META[status].className}`}>
+                            {STATUS_META[status].label}
+                          </Badge>
+                          <span className="text-[10px] text-muted-foreground/30">{link.source === "submission" ? "申请" : link.source === "imported" ? "导入" : "手动"}</span>
+                        </div>
+                        <p className="mt-[6px] line-clamp-2 text-[12px] leading-[1.6] text-muted-foreground/62">{link.description || "无简介"}</p>
+                        <div className="mt-[8px] flex flex-wrap items-center gap-x-[10px] gap-y-[4px] text-[11px] text-muted-foreground/32">
+                          <a href={link.url} target="_blank" rel="noopener noreferrer" className="inline-flex max-w-[260px] items-center gap-[4px] truncate hover:text-foreground/70">
+                            <ExternalLink className="h-[10px] w-[10px] shrink-0" />
+                            {link.url}
+                          </a>
+                          <span>排序 {link.sortOrder}</span>
+                          <span>{formatDate(link.createdAt)}</span>
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-[2px] md:opacity-0 md:transition-opacity md:group-hover:opacity-100">
+                        {status !== "approved" && (
+                          <button type="button" onClick={() => runAction(link.id, "approve")} disabled={processing === link.id} title="通过" className="rounded-md p-[7px] text-muted-foreground/35 transition-colors hover:bg-emerald-500/10 hover:text-emerald-500 disabled:opacity-40">
+                            <Check className="h-[14px] w-[14px]" />
+                          </button>
+                        )}
+                        {status !== "rejected" && (
+                          <button type="button" onClick={() => runAction(link.id, "reject")} disabled={processing === link.id} title="拒绝" className="rounded-md p-[7px] text-muted-foreground/35 transition-colors hover:bg-amber-500/10 hover:text-amber-500 disabled:opacity-40">
+                            <X className="h-[14px] w-[14px]" />
+                          </button>
+                        )}
+                        <button type="button" onClick={() => setForm(toForm(link))} title="编辑" className="rounded-md p-[7px] text-muted-foreground/35 transition-colors hover:bg-muted/50 hover:text-foreground">
+                          <Edit3 className="h-[14px] w-[14px]" />
+                        </button>
+                        <button type="button" onClick={() => runAction(link.id, "delete")} disabled={processing === link.id} title="删除" className="rounded-md p-[7px] text-muted-foreground/35 transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-40">
+                          <Trash2 className="h-[14px] w-[14px]" />
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <aside className="h-fit rounded-md border border-border/25 bg-card/10">
+          <div className="flex items-center justify-between border-b border-border/15 px-[14px] py-[10px]">
+            <h2 className="text-[13px] font-medium">{form.id ? "编辑友链" : "新建友链"}</h2>
+            {form.id && (
+              <button type="button" onClick={resetForm} className="rounded-md p-[6px] text-muted-foreground/40 hover:bg-muted/50 hover:text-foreground" title="清空">
+                <X className="h-[13px] w-[13px]" />
+              </button>
+            )}
+          </div>
+          <form className="space-y-[10px] p-[14px]" onSubmit={submit}>
+            <input value={form.name} onChange={(e) => updateField("name", e.target.value)} className={inputClass} placeholder="站点名称" />
+            <input value={form.url} onChange={(e) => updateField("url", e.target.value)} className={inputClass} placeholder="https://example.com" />
+            <textarea
+              value={form.description}
+              onChange={(e) => updateField("description", e.target.value)}
+              rows={4}
+              className="w-full resize-y rounded-md border border-border/25 bg-background/30 px-[10px] py-[10px] text-[13px] leading-[1.7] text-foreground outline-none transition-colors placeholder:text-muted-foreground/30 focus:border-foreground/20"
+              placeholder="简介"
+            />
+            <input value={form.avatarUrl} onChange={(e) => updateField("avatarUrl", e.target.value)} className={inputClass} placeholder="头像 URL" />
+            <div className="grid grid-cols-2 gap-[8px]">
+              <input value={form.ownerName} onChange={(e) => updateField("ownerName", e.target.value)} className={inputClass} placeholder="联系人" />
+              <input value={form.ownerEmail} onChange={(e) => updateField("ownerEmail", e.target.value)} className={inputClass} placeholder="邮箱" />
+            </div>
+            <div className="grid grid-cols-[1fr_96px] gap-[8px]">
+              <select value={form.status} onChange={(e) => updateField("status", e.target.value as FriendLinkStatus)} className={inputClass}>
+                <option value="pending">待审核</option>
+                <option value="approved">已通过</option>
+                <option value="rejected">已拒绝</option>
+              </select>
+              <input type="number" value={form.sortOrder} onChange={(e) => updateField("sortOrder", Number(e.target.value) || 0)} className={inputClass} placeholder="排序" />
+            </div>
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex h-[38px] w-full items-center justify-center gap-[8px] rounded-md bg-foreground text-[13px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              <Save className="h-[14px] w-[14px]" />
+              {saving ? "保存中..." : "保存"}
+            </button>
+          </form>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/friends.tsx
+++ b/client/src/pages/friends.tsx
@@ -30,17 +30,27 @@ function getInitial(name: string) {
 export function FriendsPage() {
   const [links, setLinks] = useState<FriendLink[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   useEffect(() => {
     document.title = "友链 | Monolith";
+    setLoading(true);
+    setLoadError(null);
     fetchFriends()
-      .then(setLinks)
-      .catch(() => setLinks([]))
+      .then((nextLinks) => {
+        setLinks(nextLinks);
+        setLoadError(null);
+      })
+      .catch((error) => {
+        setLinks([]);
+        setLoadError(error instanceof Error ? error.message : "获取友链失败");
+      })
       .finally(() => setLoading(false));
-  }, []);
+  }, [retryKey]);
 
   const sortedLinks = useMemo(
     () => [...links].sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name, "zh-CN")),
@@ -102,6 +112,17 @@ export function FriendsPage() {
               {[1, 2, 3, 4].map((item) => (
                 <div key={item} className="h-[116px] animate-pulse rounded-md border border-border/20 bg-card/15" />
               ))}
+            </div>
+          ) : loadError ? (
+            <div className="rounded-md border border-dashed border-red-500/25 bg-red-500/5 px-[18px] py-[40px] text-center">
+              <p className="text-[13px] text-red-500/80">{loadError}</p>
+              <button
+                type="button"
+                onClick={() => setRetryKey((value) => value + 1)}
+                className="mt-[12px] inline-flex h-[38px] items-center justify-center rounded-md border border-border/30 px-[12px] text-[12px] text-muted-foreground transition-colors hover:border-foreground/25 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              >
+                重试
+              </button>
             </div>
           ) : sortedLinks.length === 0 ? (
             <div className="rounded-md border border-dashed border-border/25 px-[18px] py-[48px] text-center">

--- a/client/src/pages/friends.tsx
+++ b/client/src/pages/friends.tsx
@@ -1,0 +1,181 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { ExternalLink, Link2, Send, Sparkles } from "lucide-react";
+import { SeoHead } from "@/components/seo-head";
+import { applyFriendLink, fetchFriends, type FriendLink } from "@/lib/api";
+
+type FormState = {
+  name: string;
+  url: string;
+  description: string;
+  avatarUrl: string;
+  ownerName: string;
+  ownerEmail: string;
+};
+
+const EMPTY_FORM: FormState = {
+  name: "",
+  url: "",
+  description: "",
+  avatarUrl: "",
+  ownerName: "",
+  ownerEmail: "",
+};
+
+const inputClass = "h-[42px] w-full rounded-md border border-border/25 bg-background/35 px-[12px] text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/35 focus:border-foreground/25";
+
+function getInitial(name: string) {
+  return name.trim().slice(0, 1).toUpperCase() || "L";
+}
+
+export function FriendsPage() {
+  const [links, setLinks] = useState<FriendLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  useEffect(() => {
+    document.title = "友链 | Monolith";
+    fetchFriends()
+      .then(setLinks)
+      .catch(() => setLinks([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const sortedLinks = useMemo(
+    () => [...links].sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name, "zh-CN")),
+    [links],
+  );
+
+  const updateField = (key: keyof FormState, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    setMessage(null);
+    if (!form.name.trim() || !form.url.trim() || !form.description.trim()) {
+      setMessage({ type: "error", text: "请填写站点名称、网址和简介" });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await applyFriendLink(form);
+      setForm(EMPTY_FORM);
+      setMessage({ type: "success", text: "申请已提交，审核通过后会展示在这里" });
+    } catch (error) {
+      setMessage({ type: "error", text: error instanceof Error ? error.message : "提交失败" });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[960px] px-[16px] py-[32px] lg:px-0 lg:py-[56px]">
+      <SeoHead
+        title="友链"
+        description="Monolith 的朋友站点与友链申请。"
+        url="/friends"
+      />
+
+      <div className="mb-[28px]">
+        <div className="mb-[10px] inline-flex items-center gap-[6px] rounded-md border border-border/25 bg-background/35 px-[10px] py-[6px] text-[12px] text-muted-foreground/70">
+          <Sparkles className="h-[13px] w-[13px]" />
+          Links
+        </div>
+        <h1 className="text-[28px] font-semibold tracking-[-0.02em] text-foreground">友链</h1>
+        <p className="mt-[8px] max-w-[620px] text-[14px] leading-[1.8] text-muted-foreground/68">
+          这里收纳一些长期关注、风格相近或彼此认识的站点。申请会先进入后台审核，避免无效链接和重复提交。
+        </p>
+      </div>
+
+      <div className="grid gap-[24px] lg:grid-cols-[1fr_340px]">
+        <section>
+          <div className="mb-[10px] flex items-center justify-between">
+            <h2 className="text-[13px] font-medium text-muted-foreground/60">已通过站点</h2>
+            <span className="text-[12px] text-muted-foreground/35">{sortedLinks.length} 个</span>
+          </div>
+
+          {loading ? (
+            <div className="grid gap-[10px] sm:grid-cols-2">
+              {[1, 2, 3, 4].map((item) => (
+                <div key={item} className="h-[116px] animate-pulse rounded-md border border-border/20 bg-card/15" />
+              ))}
+            </div>
+          ) : sortedLinks.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border/25 px-[18px] py-[48px] text-center">
+              <Link2 className="mx-auto mb-[10px] h-[22px] w-[22px] text-muted-foreground/24" />
+              <p className="text-[13px] text-muted-foreground/55">暂时还没有展示中的友链</p>
+            </div>
+          ) : (
+            <div className="grid gap-[10px] sm:grid-cols-2">
+              {sortedLinks.map((link) => (
+                <a
+                  key={link.id}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group rounded-md border border-border/25 bg-card/10 p-[14px] transition-all duration-300 hover:-translate-y-[2px] hover:border-foreground/20 hover:bg-card/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  <div className="flex items-start gap-[12px]">
+                    <div className="flex h-[42px] w-[42px] shrink-0 items-center justify-center overflow-hidden rounded-md border border-border/20 bg-background/40 text-[15px] font-semibold text-muted-foreground/70">
+                      {link.avatarUrl ? (
+                        <img src={link.avatarUrl} alt="" className="h-full w-full object-cover" loading="lazy" />
+                      ) : (
+                        getInitial(link.name)
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-[6px]">
+                        <h3 className="truncate text-[14px] font-medium text-foreground">{link.name}</h3>
+                        <ExternalLink className="h-[12px] w-[12px] shrink-0 text-muted-foreground/30 transition-colors group-hover:text-foreground/60" />
+                      </div>
+                      <p className="mt-[6px] line-clamp-2 min-h-[40px] text-[12px] leading-[1.7] text-muted-foreground/62">
+                        {link.description || "这个站点还没有填写简介。"}
+                      </p>
+                      <p className="mt-[8px] truncate text-[11px] text-muted-foreground/32">{link.url}</p>
+                    </div>
+                  </div>
+                </a>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <aside className="h-fit rounded-md border border-border/25 bg-card/10 p-[16px]">
+          <h2 className="mb-[12px] text-[14px] font-medium text-foreground">申请友链</h2>
+          <form className="space-y-[10px]" onSubmit={submit}>
+            <input value={form.name} onChange={(e) => updateField("name", e.target.value)} className={inputClass} placeholder="站点名称" />
+            <input value={form.url} onChange={(e) => updateField("url", e.target.value)} className={inputClass} placeholder="https://example.com" />
+            <textarea
+              value={form.description}
+              onChange={(e) => updateField("description", e.target.value)}
+              rows={4}
+              className="w-full resize-y rounded-md border border-border/25 bg-background/35 px-[12px] py-[10px] text-[13px] leading-[1.7] text-foreground outline-none transition-colors placeholder:text-muted-foreground/35 focus:border-foreground/25"
+              placeholder="一句话介绍你的站点"
+            />
+            <input value={form.avatarUrl} onChange={(e) => updateField("avatarUrl", e.target.value)} className={inputClass} placeholder="头像 URL，可选" />
+            <div className="grid gap-[10px] sm:grid-cols-2 lg:grid-cols-1">
+              <input value={form.ownerName} onChange={(e) => updateField("ownerName", e.target.value)} className={inputClass} placeholder="联系人，可选" />
+              <input value={form.ownerEmail} onChange={(e) => updateField("ownerEmail", e.target.value)} className={inputClass} placeholder="邮箱，可选" />
+            </div>
+            {message && (
+              <div className={`rounded-md border px-[12px] py-[10px] text-[12px] ${message.type === "success" ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-500" : "border-red-500/20 bg-red-500/10 text-red-500"}`}>
+                {message.text}
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex h-[42px] w-full items-center justify-center gap-[8px] rounded-md bg-foreground px-[14px] text-[13px] font-medium text-background transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              <Send className="h-[14px] w-[14px]" />
+              {submitting ? "提交中..." : "提交申请"}
+            </button>
+          </form>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/server/src/db/schema-pg.ts
+++ b/server/src/db/schema-pg.ts
@@ -87,6 +87,30 @@ export const pgComments = pgTable(
   })
 );
 
+/* ── 友链表 ──────────────────────────────── */
+export const pgFriendLinks = pgTable(
+  "friend_links",
+  {
+    id: serial("id").primaryKey(),
+    name: text("name").notNull(),
+    url: text("url").notNull(),
+    description: text("description").notNull().default(""),
+    avatarUrl: text("avatar_url").notNull().default(""),
+    ownerName: text("owner_name").notNull().default(""),
+    ownerEmail: text("owner_email").notNull().default(""),
+    status: text("status").notNull().default("pending"),
+    source: text("source").notNull().default("manual"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+    reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
+  },
+  (table) => ({
+    urlIdx: uniqueIndex("pg_friend_links_url_idx").on(table.url),
+    statusIdx: index("pg_friend_links_status_idx").on(table.status),
+  })
+);
+
 /* ── 表情反应表 ────────────────────────────── */
 export const pgReactions = pgTable("reactions", {
   id: serial("id").primaryKey(),

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -86,6 +86,34 @@ export const comments = sqliteTable(
   })
 );
 
+/* ── 友链表 ──────────────────────────────── */
+export const friendLinks = sqliteTable(
+  "friend_links",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    name: text("name").notNull(),
+    url: text("url").notNull(),
+    description: text("description").notNull().default(""),
+    avatarUrl: text("avatar_url").notNull().default(""),
+    ownerName: text("owner_name").notNull().default(""),
+    ownerEmail: text("owner_email").notNull().default(""),
+    status: text("status").notNull().default("pending"),
+    source: text("source").notNull().default("manual"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    createdAt: text("created_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at")
+      .notNull()
+      .default(sql`(datetime('now'))`),
+    reviewedAt: text("reviewed_at"),
+  },
+  (table) => ({
+    urlIdx: uniqueIndex("friend_links_url_idx").on(table.url),
+    statusIdx: index("friend_links_status_idx").on(table.status),
+  })
+);
+
 /* ── 表情反应表 ────────────────────────────── */
 export const reactions = sqliteTable("reactions", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -158,6 +158,21 @@ function normalizePublicUrl(value: unknown): string {
   }
 }
 
+function isUniqueConstraintError(error: unknown): boolean {
+  const details = error && typeof error === "object"
+    ? error as { code?: unknown; message?: unknown; cause?: unknown }
+    : {};
+  const code = String(details.code || "");
+  const message = String(details.message || error || "").toLowerCase();
+  return code === "23505"
+    || code === "SQLITE_CONSTRAINT_UNIQUE"
+    || code === "SQLITE_CONSTRAINT"
+    || message.includes("unique constraint")
+    || message.includes("duplicate key")
+    || message.includes("already exists")
+    || (details.cause !== error && isUniqueConstraintError(details.cause));
+}
+
 function parseSocialLinksSetting(value: string): CreateFriendLinkInput[] {
   if (!value.trim()) return [];
   try {
@@ -698,8 +713,12 @@ app.post("/api/friends/apply", async (c) => {
     });
     await triggerWebhook(c, "friend_link_submitted", { id: link.id, name, url });
     return c.json({ success: true }, 201);
-  } catch {
-    return c.json({ error: "该站点 URL 已提交或已存在" }, 409);
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return c.json({ error: "该站点 URL 已提交或已存在" }, 409);
+    }
+    console.error("Failed to create friend link submission", error);
+    return c.json({ error: "友链申请暂时无法提交，请稍后再试" }, 500);
   }
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,7 +9,7 @@ import { cors } from "hono/cors";
 import { sign, verify } from "hono/jwt";
 import type { Context } from "hono";
 import { createDatabase, createObjectStorage } from "./storage/factory";
-import type { CreatePostInput, IDatabase } from "./storage/interfaces";
+import type { CreateFriendLinkInput, CreatePostInput, FriendLink, IDatabase } from "./storage/interfaces";
 import type { IObjectStorage } from "./storage/interfaces";
 import { writeAnalyticsPoint, isWebsiteAllowed } from "./analytics/ae-tracker";
 import { queryAEAnalytics } from "./analytics/ae-query";
@@ -131,6 +131,70 @@ async function readJson<T>(c: AppContext): Promise<{ ok: true; body: T } | { ok:
   } catch {
     return { ok: false, response: c.json({ error: "请求体必须是有效 JSON" }, 400) };
   }
+}
+
+function normalizeText(value: unknown, maxLength: number): string {
+  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+}
+
+function normalizeOptionalEmail(value: unknown): string {
+  const email = normalizeText(value, 160);
+  if (!email) return "";
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : "";
+}
+
+function normalizePublicUrl(value: unknown): string {
+  const raw = normalizeText(value, 500);
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return "";
+    parsed.username = "";
+    parsed.password = "";
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return "";
+  }
+}
+
+function parseSocialLinksSetting(value: string): CreateFriendLinkInput[] {
+  if (!value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    const links: CreateFriendLinkInput[] = [];
+    parsed.forEach((item, index) => {
+      if (!item || typeof item !== "object") return;
+      const record = item as Record<string, unknown>;
+      const url = normalizePublicUrl(record.url);
+      const name = normalizeText(record.label, 80) || normalizeText(record.title, 80);
+      const enabled = record.enabled !== false;
+      if (!enabled || !url || !name) return;
+      links.push({
+        name,
+        url,
+        description: normalizeText(record.description, 240),
+        status: "approved",
+        source: "imported",
+        sortOrder: index,
+      });
+    });
+    return links;
+  } catch {
+    return [];
+  }
+}
+
+function publicFriendLink(link: FriendLink) {
+  return {
+    id: link.id,
+    name: link.name,
+    url: link.url,
+    description: link.description,
+    avatarUrl: link.avatarUrl,
+    sortOrder: link.sortOrder,
+  };
 }
 
 async function readObjectBody(body: ReadableStream<Uint8Array>): Promise<string> {
@@ -579,6 +643,66 @@ app.get("/api/settings/public", async (c) => {
   });
 });
 
+app.get("/api/friends", async (c) => {
+  const db = c.get("db");
+  const links = await db.getApprovedFriendLinks();
+  if (links.length > 0) {
+    return c.json(links.map(publicFriendLink));
+  }
+
+  const settings = await db.getSettings();
+  const legacyLinks = parseSocialLinksSetting(settings.social_links || "");
+  return c.json(legacyLinks.map((link, index) => ({
+    id: -index - 1,
+    name: link.name,
+    url: link.url,
+    description: link.description || "",
+    avatarUrl: link.avatarUrl || "",
+    sortOrder: link.sortOrder ?? index,
+  })));
+});
+
+app.post("/api/friends/apply", async (c) => {
+  const ip = getClientIp(c);
+  if (isFriendLinkRateLimited(ip, Date.now())) {
+    return c.json({ error: "提交过于频繁，请稍后再试" }, 429);
+  }
+
+  const parsed = await readJson<Record<string, unknown>>(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+  const name = normalizeText(body.name, 80);
+  const url = normalizePublicUrl(body.url);
+  const description = normalizeText(body.description, 240);
+  const avatarUrl = normalizePublicUrl(body.avatarUrl);
+  const ownerName = normalizeText(body.ownerName, 80);
+  const ownerEmail = normalizeOptionalEmail(body.ownerEmail);
+
+  if (!name || !url || !description) {
+    return c.json({ error: "请填写站点名称、有效 URL 和简介" }, 400);
+  }
+  if (body.ownerEmail && !ownerEmail) {
+    return c.json({ error: "联系邮箱格式无效" }, 400);
+  }
+
+  try {
+    const link = await c.get("db").createFriendLink({
+      name,
+      url,
+      description,
+      avatarUrl,
+      ownerName,
+      ownerEmail,
+      status: "pending",
+      source: "submission",
+    });
+    await triggerWebhook(c, "friend_link_submitted", { id: link.id, name, url });
+    return c.json({ success: true }, 201);
+  } catch {
+    return c.json({ error: "该站点 URL 已提交或已存在" }, 409);
+  }
+});
+
 // 公开流量统计（侧边栏折线图）
 app.get("/api/stats/traffic", async (c) => {
   const db = c.get("db");
@@ -717,6 +841,10 @@ const loginAttempts = new Map<string, { count: number; firstAttempt: number }>()
 const LOGIN_RATE_LIMIT = 5;       // 最多 5 次
 const LOGIN_RATE_WINDOW = 15 * 60 * 1000; // 15 分钟窗口
 const LOGIN_RATE_MAX_KEYS = 1000;
+const friendLinkAttempts = new Map<string, { count: number; firstAttempt: number }>();
+const FRIEND_LINK_RATE_LIMIT = 3;
+const FRIEND_LINK_RATE_WINDOW = 60 * 60 * 1000;
+const FRIEND_LINK_RATE_MAX_KEYS = 1000;
 
 function getClientIp(c: any): string {
   const cfIp = c.req.header("CF-Connecting-IP")?.trim();
@@ -733,6 +861,31 @@ function pruneLoginAttempts(now: number) {
     if (!oldest) break;
     loginAttempts.delete(oldest);
   }
+}
+
+function pruneFriendLinkAttempts(now: number) {
+  for (const [ip, record] of friendLinkAttempts.entries()) {
+    if ((now - record.firstAttempt) >= FRIEND_LINK_RATE_WINDOW) friendLinkAttempts.delete(ip);
+  }
+  while (friendLinkAttempts.size > FRIEND_LINK_RATE_MAX_KEYS) {
+    const oldest = friendLinkAttempts.keys().next().value;
+    if (!oldest) break;
+    friendLinkAttempts.delete(oldest);
+  }
+}
+
+function isFriendLinkRateLimited(ip: string, now: number): boolean {
+  pruneFriendLinkAttempts(now);
+  const record = friendLinkAttempts.get(ip);
+  if (record && record.count >= FRIEND_LINK_RATE_LIMIT && (now - record.firstAttempt) < FRIEND_LINK_RATE_WINDOW) {
+    return true;
+  }
+  if (!record || (now - record.firstAttempt) >= FRIEND_LINK_RATE_WINDOW) {
+    friendLinkAttempts.set(ip, { count: 1, firstAttempt: now });
+  } else {
+    record.count++;
+  }
+  return false;
 }
 
 function getMissingAuthSecrets(env: Partial<Bindings>) {
@@ -1264,6 +1417,91 @@ app.put("/api/admin/settings", async (c) => {
   const body = parsed.body;
   await db.saveSettings(body);
   return c.json({ success: true });
+});
+
+app.get("/api/admin/friends", async (c) => {
+  const links = await c.get("db").getAllFriendLinks();
+  return c.json(links);
+});
+
+app.post("/api/admin/friends", async (c) => {
+  const parsed = await readJson<Record<string, unknown>>(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+  const name = normalizeText(body.name, 80);
+  const url = normalizePublicUrl(body.url);
+  if (!name || !url) return c.json({ error: "请填写名称和有效 URL" }, 400);
+
+  try {
+    const link = await c.get("db").createFriendLink({
+      name,
+      url,
+      description: normalizeText(body.description, 240),
+      avatarUrl: normalizePublicUrl(body.avatarUrl),
+      ownerName: normalizeText(body.ownerName, 80),
+      ownerEmail: normalizeOptionalEmail(body.ownerEmail),
+      status: body.status === "pending" || body.status === "rejected" ? body.status : "approved",
+      source: "manual",
+      sortOrder: typeof body.sortOrder === "number" ? body.sortOrder : 0,
+    });
+    return c.json(link, 201);
+  } catch {
+    return c.json({ error: "该 URL 已存在" }, 409);
+  }
+});
+
+app.put("/api/admin/friends/:id", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id)) return c.json({ error: "无效 ID" }, 400);
+  const parsed = await readJson<Record<string, unknown>>(c);
+  if (!parsed.ok) return parsed.response;
+  const body = parsed.body;
+  const url = body.url === undefined ? undefined : normalizePublicUrl(body.url);
+  if (body.url !== undefined && !url) return c.json({ error: "URL 无效" }, 400);
+
+  const updated = await c.get("db").updateFriendLink(id, {
+    ...(body.name !== undefined && { name: normalizeText(body.name, 80) }),
+    ...(url !== undefined && { url }),
+    ...(body.description !== undefined && { description: normalizeText(body.description, 240) }),
+    ...(body.avatarUrl !== undefined && { avatarUrl: normalizePublicUrl(body.avatarUrl) }),
+    ...(body.ownerName !== undefined && { ownerName: normalizeText(body.ownerName, 80) }),
+    ...(body.ownerEmail !== undefined && { ownerEmail: normalizeOptionalEmail(body.ownerEmail) }),
+    ...(body.status === "pending" || body.status === "approved" || body.status === "rejected" ? { status: body.status } : {}),
+    ...(typeof body.sortOrder === "number" && { sortOrder: body.sortOrder }),
+  });
+  if (!updated) return c.json({ error: "友链不存在" }, 404);
+  return c.json(updated);
+});
+
+app.post("/api/admin/friends/:id/approve", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id)) return c.json({ error: "无效 ID" }, 400);
+  const ok = await c.get("db").approveFriendLink(id);
+  if (!ok) return c.json({ error: "友链不存在" }, 404);
+  return c.json({ success: true });
+});
+
+app.post("/api/admin/friends/:id/reject", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id)) return c.json({ error: "无效 ID" }, 400);
+  const ok = await c.get("db").rejectFriendLink(id);
+  if (!ok) return c.json({ error: "友链不存在" }, 404);
+  return c.json({ success: true });
+});
+
+app.delete("/api/admin/friends/:id", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id)) return c.json({ error: "无效 ID" }, 400);
+  const ok = await c.get("db").deleteFriendLink(id);
+  if (!ok) return c.json({ error: "友链不存在" }, 404);
+  return c.json({ success: true });
+});
+
+app.post("/api/admin/friends/import-social-links", async (c) => {
+  const settings = await c.get("db").getSettings();
+  const links = parseSocialLinksSetting(settings.social_links || "");
+  const imported = await c.get("db").importFriendLinks(links);
+  return c.json({ imported });
 });
 
 /* ── 数据备份 ──────────────────────────────── */

--- a/server/src/migrations/0010_friend_links.sql
+++ b/server/src/migrations/0010_friend_links.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS friend_links (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL DEFAULT '',
+  avatar_url TEXT NOT NULL DEFAULT '',
+  owner_name TEXT NOT NULL DEFAULT '',
+  owner_email TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'pending',
+  source TEXT NOT NULL DEFAULT 'manual',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  reviewed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS friend_links_status_idx ON friend_links(status);

--- a/server/src/storage/db/d1.ts
+++ b/server/src/storage/db/d1.ts
@@ -5,11 +5,11 @@
 
 import { drizzle } from "drizzle-orm/d1";
 import { eq, desc, sql, inArray } from "drizzle-orm";
-import { posts, tags, postTags, pages, comments, reactions, visits, postVersions } from "../../db/schema";
+import { posts, tags, postTags, pages, comments, friendLinks, reactions, visits, postVersions } from "../../db/schema";
 import type {
   IDatabase, Post, PostSummary, Tag, Page, PageSummary,
   CreatePostInput, UpdatePostInput, UpsertPageInput,
-  BackupData, ImportResult, ViewStats, Comment, CreateCommentInput, PostVersion,
+  BackupData, ImportResult, ViewStats, Comment, CreateCommentInput, FriendLink, CreateFriendLinkInput, UpdateFriendLinkInput, PostVersion,
 } from "../interfaces";
 
 type DrizzleD1 = ReturnType<typeof drizzle>;
@@ -34,6 +34,7 @@ export class D1Adapter implements IDatabase {
         await this.ensureSettingsTable();
         await this.ensurePagesTable();
         await this.ensureCommentsTable();
+        await this.ensureFriendLinksTable();
         await this.ensureSeriesColumns();
         await this.ensureReactionsTable();
         await this.ensureVisitsTable();
@@ -68,6 +69,7 @@ export class D1Adapter implements IDatabase {
       settings: ["key", "value"],
       pages: ["id", "slug", "title", "content", "sort_order", "published", "show_in_nav", "created_at", "updated_at"],
       comments: ["id", "post_id", "author_name", "author_email", "content", "approved", "created_at"],
+      friend_links: ["id", "name", "url", "description", "avatar_url", "owner_name", "owner_email", "status", "source", "sort_order", "created_at", "updated_at", "reviewed_at"],
       reactions: ["id", "post_slug", "type", "ip_hash", "created_at"],
       visits: ["id", "path", "country", "referer_domain", "device_type", "created_at"],
     };
@@ -227,6 +229,25 @@ export class D1Adapter implements IDatabase {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )`);
     await this.db.run(sql`CREATE INDEX IF NOT EXISTS comments_post_id_idx ON comments(post_id)`);
+  }
+
+  private async ensureFriendLinksTable(): Promise<void> {
+    await this.db.run(sql`CREATE TABLE IF NOT EXISTS friend_links (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      url TEXT NOT NULL UNIQUE,
+      description TEXT NOT NULL DEFAULT '',
+      avatar_url TEXT NOT NULL DEFAULT '',
+      owner_name TEXT NOT NULL DEFAULT '',
+      owner_email TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      source TEXT NOT NULL DEFAULT 'manual',
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      reviewed_at TEXT
+    )`);
+    await this.db.run(sql`CREATE INDEX IF NOT EXISTS friend_links_status_idx ON friend_links(status)`);
   }
 
   /* ── 文章 ─────────────────────── */
@@ -1002,6 +1023,125 @@ export class D1Adapter implements IDatabase {
           WHERE p.slug = ${postSlug} AND c.approved = 1`
     );
     return (result.results?.[0] as { count: number } | undefined)?.count ?? 0;
+  }
+
+  /* ── 友链 ─────────────────── */
+
+  private toFriendLink(row: typeof friendLinks.$inferSelect): FriendLink {
+    return {
+      id: row.id,
+      name: row.name,
+      url: row.url,
+      description: row.description,
+      avatarUrl: row.avatarUrl,
+      ownerName: row.ownerName,
+      ownerEmail: row.ownerEmail,
+      status: row.status as FriendLink["status"],
+      source: row.source as FriendLink["source"],
+      sortOrder: row.sortOrder,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      reviewedAt: row.reviewedAt,
+    };
+  }
+
+  async getApprovedFriendLinks(): Promise<FriendLink[]> {
+    await this.ensureFriendLinksTable();
+    const rows = await this.db
+      .select()
+      .from(friendLinks)
+      .where(eq(friendLinks.status, "approved"))
+      .orderBy(friendLinks.sortOrder, friendLinks.name);
+    return rows.map((row) => this.toFriendLink(row));
+  }
+
+  async getAllFriendLinks(): Promise<FriendLink[]> {
+    await this.ensureFriendLinksTable();
+    const rows = await this.db
+      .select()
+      .from(friendLinks)
+      .orderBy(friendLinks.sortOrder, desc(friendLinks.createdAt));
+    return rows.map((row) => this.toFriendLink(row));
+  }
+
+  async createFriendLink(input: CreateFriendLinkInput): Promise<FriendLink> {
+    await this.ensureFriendLinksTable();
+    const [created] = await this.db
+      .insert(friendLinks)
+      .values({
+        name: input.name,
+        url: input.url,
+        description: input.description || "",
+        avatarUrl: input.avatarUrl || "",
+        ownerName: input.ownerName || "",
+        ownerEmail: input.ownerEmail || "",
+        status: input.status || "pending",
+        source: input.source || "manual",
+        sortOrder: input.sortOrder ?? 0,
+        reviewedAt: input.status === "approved" || input.status === "rejected" ? sql`datetime('now')` as never : null,
+      })
+      .returning();
+    return this.toFriendLink(created);
+  }
+
+  async updateFriendLink(id: number, input: UpdateFriendLinkInput): Promise<FriendLink | null> {
+    await this.ensureFriendLinksTable();
+    const patch = {
+      ...(input.name !== undefined && { name: input.name }),
+      ...(input.url !== undefined && { url: input.url }),
+      ...(input.description !== undefined && { description: input.description }),
+      ...(input.avatarUrl !== undefined && { avatarUrl: input.avatarUrl }),
+      ...(input.ownerName !== undefined && { ownerName: input.ownerName }),
+      ...(input.ownerEmail !== undefined && { ownerEmail: input.ownerEmail }),
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.source !== undefined && { source: input.source }),
+      ...(input.sortOrder !== undefined && { sortOrder: input.sortOrder }),
+      ...(input.status === "approved" || input.status === "rejected" ? { reviewedAt: sql`datetime('now')` as never } : {}),
+      updatedAt: sql`datetime('now')` as never,
+    };
+    const [updated] = await this.db.update(friendLinks).set(patch).where(eq(friendLinks.id, id)).returning();
+    return updated ? this.toFriendLink(updated) : null;
+  }
+
+  async approveFriendLink(id: number): Promise<boolean> {
+    return Boolean(await this.updateFriendLink(id, { status: "approved" }));
+  }
+
+  async rejectFriendLink(id: number): Promise<boolean> {
+    return Boolean(await this.updateFriendLink(id, { status: "rejected" }));
+  }
+
+  async deleteFriendLink(id: number): Promise<boolean> {
+    await this.ensureFriendLinksTable();
+    const result = await this.db.delete(friendLinks).where(eq(friendLinks.id, id)).returning();
+    return result.length > 0;
+  }
+
+  async importFriendLinks(input: CreateFriendLinkInput[]): Promise<number> {
+    await this.ensureFriendLinksTable();
+    let imported = 0;
+    for (const item of input) {
+      await this.db
+        .insert(friendLinks)
+        .values({
+          name: item.name,
+          url: item.url,
+          description: item.description || "",
+          avatarUrl: item.avatarUrl || "",
+          ownerName: item.ownerName || "",
+          ownerEmail: item.ownerEmail || "",
+          status: item.status || "approved",
+          source: item.source || "imported",
+          sortOrder: item.sortOrder ?? 0,
+          reviewedAt: sql`datetime('now')` as never,
+        })
+        .onConflictDoNothing()
+        .returning()
+        .then((rows) => {
+          imported += rows.length;
+        });
+    }
+    return imported;
   }
 
   async getSeriesPosts(seriesSlug: string): Promise<{ slug: string; title: string; seriesOrder: number }[]> {

--- a/server/src/storage/db/postgres.ts
+++ b/server/src/storage/db/postgres.ts
@@ -7,11 +7,11 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { eq, desc, sql, inArray } from "drizzle-orm";
-import { pgPosts, pgTags, pgPostTags, pgPages, pgSettings, pgComments, pgReactions, pgVisits, pgPostVersions } from "../../db/schema-pg";
+import { pgPosts, pgTags, pgPostTags, pgPages, pgSettings, pgComments, pgFriendLinks, pgReactions, pgVisits, pgPostVersions } from "../../db/schema-pg";
 import type {
   IDatabase, Post, PostSummary, Tag, Page, PageSummary,
   CreatePostInput, UpdatePostInput, UpsertPageInput,
-  BackupData, ImportResult, ViewStats, Comment, CreateCommentInput, PostVersion
+  BackupData, ImportResult, ViewStats, Comment, CreateCommentInput, FriendLink, CreateFriendLinkInput, UpdateFriendLinkInput, PostVersion
 } from "../interfaces";
 
 type DrizzlePG = ReturnType<typeof drizzle>;
@@ -116,6 +116,24 @@ export class PostgresAdapter implements IDatabase {
     `;
     await this.client`CREATE INDEX IF NOT EXISTS pg_comments_post_id_idx ON comments(post_id)`;
     await this.client`
+      CREATE TABLE IF NOT EXISTS friend_links (
+        id SERIAL PRIMARY KEY,
+        name TEXT NOT NULL,
+        url TEXT NOT NULL UNIQUE,
+        description TEXT NOT NULL DEFAULT '',
+        avatar_url TEXT NOT NULL DEFAULT '',
+        owner_name TEXT NOT NULL DEFAULT '',
+        owner_email TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        source TEXT NOT NULL DEFAULT 'manual',
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        reviewed_at TIMESTAMPTZ
+      )
+    `;
+    await this.client`CREATE INDEX IF NOT EXISTS pg_friend_links_status_idx ON friend_links(status)`;
+    await this.client`
       CREATE TABLE IF NOT EXISTS post_versions (
         id SERIAL PRIMARY KEY,
         post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
@@ -200,6 +218,10 @@ export class PostgresAdapter implements IDatabase {
   private ts(d: Date | string | null): string {
     if (!d) return new Date().toISOString();
     return d instanceof Date ? d.toISOString() : d;
+  }
+
+  private nullableTs(d: Date | string | null): string | null {
+    return d ? this.ts(d) : null;
   }
 
   /* ── 文章 ─────────────────────── */
@@ -968,6 +990,125 @@ export class PostgresAdapter implements IDatabase {
       WHERE p.slug = ${postSlug} AND c.approved = true
     `;
     return row?.count ?? 0;
+  }
+
+  /* ── 友链 ─────────────────── */
+
+  private toFriendLink(row: typeof pgFriendLinks.$inferSelect): FriendLink {
+    return {
+      id: row.id,
+      name: row.name,
+      url: row.url,
+      description: row.description,
+      avatarUrl: row.avatarUrl,
+      ownerName: row.ownerName,
+      ownerEmail: row.ownerEmail,
+      status: row.status as FriendLink["status"],
+      source: row.source as FriendLink["source"],
+      sortOrder: row.sortOrder,
+      createdAt: this.ts(row.createdAt),
+      updatedAt: this.ts(row.updatedAt),
+      reviewedAt: this.nullableTs(row.reviewedAt),
+    };
+  }
+
+  async getApprovedFriendLinks(): Promise<FriendLink[]> {
+    await this.ensureCoreTables();
+    const rows = await this.db
+      .select()
+      .from(pgFriendLinks)
+      .where(eq(pgFriendLinks.status, "approved"))
+      .orderBy(pgFriendLinks.sortOrder, pgFriendLinks.name);
+    return rows.map((row) => this.toFriendLink(row));
+  }
+
+  async getAllFriendLinks(): Promise<FriendLink[]> {
+    await this.ensureCoreTables();
+    const rows = await this.db
+      .select()
+      .from(pgFriendLinks)
+      .orderBy(pgFriendLinks.sortOrder, desc(pgFriendLinks.createdAt));
+    return rows.map((row) => this.toFriendLink(row));
+  }
+
+  async createFriendLink(input: CreateFriendLinkInput): Promise<FriendLink> {
+    await this.ensureCoreTables();
+    const [created] = await this.db
+      .insert(pgFriendLinks)
+      .values({
+        name: input.name,
+        url: input.url,
+        description: input.description || "",
+        avatarUrl: input.avatarUrl || "",
+        ownerName: input.ownerName || "",
+        ownerEmail: input.ownerEmail || "",
+        status: input.status || "pending",
+        source: input.source || "manual",
+        sortOrder: input.sortOrder ?? 0,
+        reviewedAt: input.status === "approved" || input.status === "rejected" ? new Date() : null,
+      })
+      .returning();
+    return this.toFriendLink(created);
+  }
+
+  async updateFriendLink(id: number, input: UpdateFriendLinkInput): Promise<FriendLink | null> {
+    await this.ensureCoreTables();
+    const patch = {
+      ...(input.name !== undefined && { name: input.name }),
+      ...(input.url !== undefined && { url: input.url }),
+      ...(input.description !== undefined && { description: input.description }),
+      ...(input.avatarUrl !== undefined && { avatarUrl: input.avatarUrl }),
+      ...(input.ownerName !== undefined && { ownerName: input.ownerName }),
+      ...(input.ownerEmail !== undefined && { ownerEmail: input.ownerEmail }),
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.source !== undefined && { source: input.source }),
+      ...(input.sortOrder !== undefined && { sortOrder: input.sortOrder }),
+      ...(input.status === "approved" || input.status === "rejected" ? { reviewedAt: new Date() } : {}),
+      updatedAt: new Date(),
+    };
+    const [updated] = await this.db.update(pgFriendLinks).set(patch).where(eq(pgFriendLinks.id, id)).returning();
+    return updated ? this.toFriendLink(updated) : null;
+  }
+
+  async approveFriendLink(id: number): Promise<boolean> {
+    return Boolean(await this.updateFriendLink(id, { status: "approved" }));
+  }
+
+  async rejectFriendLink(id: number): Promise<boolean> {
+    return Boolean(await this.updateFriendLink(id, { status: "rejected" }));
+  }
+
+  async deleteFriendLink(id: number): Promise<boolean> {
+    await this.ensureCoreTables();
+    const result = await this.db.delete(pgFriendLinks).where(eq(pgFriendLinks.id, id)).returning();
+    return result.length > 0;
+  }
+
+  async importFriendLinks(input: CreateFriendLinkInput[]): Promise<number> {
+    await this.ensureCoreTables();
+    let imported = 0;
+    for (const item of input) {
+      await this.db
+        .insert(pgFriendLinks)
+        .values({
+          name: item.name,
+          url: item.url,
+          description: item.description || "",
+          avatarUrl: item.avatarUrl || "",
+          ownerName: item.ownerName || "",
+          ownerEmail: item.ownerEmail || "",
+          status: item.status || "approved",
+          source: item.source || "imported",
+          sortOrder: item.sortOrder ?? 0,
+          reviewedAt: new Date(),
+        })
+        .onConflictDoNothing()
+        .returning()
+        .then((rows) => {
+          imported += rows.length;
+        });
+    }
+    return imported;
   }
 
   async getSeriesPosts(seriesSlug: string): Promise<{ slug: string; title: string; seriesOrder: number }[]> {

--- a/server/src/storage/db/turso.ts
+++ b/server/src/storage/db/turso.ts
@@ -7,11 +7,11 @@
 import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 import { eq, desc, sql, inArray } from "drizzle-orm";
-import { posts, tags, postTags, pages, comments, reactions, visits, postVersions } from "../../db/schema";
+import { posts, tags, postTags, pages, comments, friendLinks, reactions, visits, postVersions } from "../../db/schema";
 import type {
   IDatabase, Post, PostSummary, Tag, Page, PageSummary,
   CreatePostInput, UpdatePostInput, UpsertPageInput,
-  BackupData, ImportResult, ViewStats, Comment, CreateCommentInput, PostVersion
+  BackupData, ImportResult, ViewStats, Comment, CreateCommentInput, FriendLink, CreateFriendLinkInput, UpdateFriendLinkInput, PostVersion
 } from "../interfaces";
 
 type DrizzleLibSQL = ReturnType<typeof drizzle>;
@@ -181,6 +181,25 @@ export class TursoAdapter implements IDatabase {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )`);
     await this.db.run(sql`CREATE INDEX IF NOT EXISTS comments_post_id_idx ON comments(post_id)`);
+  }
+
+  private async ensureFriendLinksTable(): Promise<void> {
+    await this.db.run(sql`CREATE TABLE IF NOT EXISTS friend_links (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      url TEXT NOT NULL UNIQUE,
+      description TEXT NOT NULL DEFAULT '',
+      avatar_url TEXT NOT NULL DEFAULT '',
+      owner_name TEXT NOT NULL DEFAULT '',
+      owner_email TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      source TEXT NOT NULL DEFAULT 'manual',
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      reviewed_at TEXT
+    )`);
+    await this.db.run(sql`CREATE INDEX IF NOT EXISTS friend_links_status_idx ON friend_links(status)`);
   }
 
   /* ── 文章 ─────────────────────── */
@@ -944,6 +963,125 @@ export class TursoAdapter implements IDatabase {
           WHERE p.slug = ${postSlug} AND c.approved = 1`
     );
     return (result.rows?.[0] as unknown as { count: number } | undefined)?.count ?? 0;
+  }
+
+  /* ── 友链 ─────────────────── */
+
+  private toFriendLink(row: typeof friendLinks.$inferSelect): FriendLink {
+    return {
+      id: row.id,
+      name: row.name,
+      url: row.url,
+      description: row.description,
+      avatarUrl: row.avatarUrl,
+      ownerName: row.ownerName,
+      ownerEmail: row.ownerEmail,
+      status: row.status as FriendLink["status"],
+      source: row.source as FriendLink["source"],
+      sortOrder: row.sortOrder,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      reviewedAt: row.reviewedAt,
+    };
+  }
+
+  async getApprovedFriendLinks(): Promise<FriendLink[]> {
+    await this.ensureFriendLinksTable();
+    const rows = await this.db
+      .select()
+      .from(friendLinks)
+      .where(eq(friendLinks.status, "approved"))
+      .orderBy(friendLinks.sortOrder, friendLinks.name);
+    return rows.map((row) => this.toFriendLink(row));
+  }
+
+  async getAllFriendLinks(): Promise<FriendLink[]> {
+    await this.ensureFriendLinksTable();
+    const rows = await this.db
+      .select()
+      .from(friendLinks)
+      .orderBy(friendLinks.sortOrder, desc(friendLinks.createdAt));
+    return rows.map((row) => this.toFriendLink(row));
+  }
+
+  async createFriendLink(input: CreateFriendLinkInput): Promise<FriendLink> {
+    await this.ensureFriendLinksTable();
+    const [created] = await this.db
+      .insert(friendLinks)
+      .values({
+        name: input.name,
+        url: input.url,
+        description: input.description || "",
+        avatarUrl: input.avatarUrl || "",
+        ownerName: input.ownerName || "",
+        ownerEmail: input.ownerEmail || "",
+        status: input.status || "pending",
+        source: input.source || "manual",
+        sortOrder: input.sortOrder ?? 0,
+        reviewedAt: input.status === "approved" || input.status === "rejected" ? sql`datetime('now')` as never : null,
+      })
+      .returning();
+    return this.toFriendLink(created);
+  }
+
+  async updateFriendLink(id: number, input: UpdateFriendLinkInput): Promise<FriendLink | null> {
+    await this.ensureFriendLinksTable();
+    const patch = {
+      ...(input.name !== undefined && { name: input.name }),
+      ...(input.url !== undefined && { url: input.url }),
+      ...(input.description !== undefined && { description: input.description }),
+      ...(input.avatarUrl !== undefined && { avatarUrl: input.avatarUrl }),
+      ...(input.ownerName !== undefined && { ownerName: input.ownerName }),
+      ...(input.ownerEmail !== undefined && { ownerEmail: input.ownerEmail }),
+      ...(input.status !== undefined && { status: input.status }),
+      ...(input.source !== undefined && { source: input.source }),
+      ...(input.sortOrder !== undefined && { sortOrder: input.sortOrder }),
+      ...(input.status === "approved" || input.status === "rejected" ? { reviewedAt: sql`datetime('now')` as never } : {}),
+      updatedAt: sql`datetime('now')` as never,
+    };
+    const [updated] = await this.db.update(friendLinks).set(patch).where(eq(friendLinks.id, id)).returning();
+    return updated ? this.toFriendLink(updated) : null;
+  }
+
+  async approveFriendLink(id: number): Promise<boolean> {
+    return Boolean(await this.updateFriendLink(id, { status: "approved" }));
+  }
+
+  async rejectFriendLink(id: number): Promise<boolean> {
+    return Boolean(await this.updateFriendLink(id, { status: "rejected" }));
+  }
+
+  async deleteFriendLink(id: number): Promise<boolean> {
+    await this.ensureFriendLinksTable();
+    const result = await this.db.delete(friendLinks).where(eq(friendLinks.id, id)).returning();
+    return result.length > 0;
+  }
+
+  async importFriendLinks(input: CreateFriendLinkInput[]): Promise<number> {
+    await this.ensureFriendLinksTable();
+    let imported = 0;
+    for (const item of input) {
+      await this.db
+        .insert(friendLinks)
+        .values({
+          name: item.name,
+          url: item.url,
+          description: item.description || "",
+          avatarUrl: item.avatarUrl || "",
+          ownerName: item.ownerName || "",
+          ownerEmail: item.ownerEmail || "",
+          status: item.status || "approved",
+          source: item.source || "imported",
+          sortOrder: item.sortOrder ?? 0,
+          reviewedAt: sql`datetime('now')` as never,
+        })
+        .onConflictDoNothing()
+        .returning()
+        .then((rows) => {
+          imported += rows.length;
+        });
+    }
+    return imported;
   }
 
   async getSeriesPosts(seriesSlug: string): Promise<{ slug: string; title: string; seriesOrder: number }[]> {

--- a/server/src/storage/interfaces.ts
+++ b/server/src/storage/interfaces.ts
@@ -149,6 +149,39 @@ export type CreateCommentInput = {
   content: string;
 };
 
+export type FriendLinkStatus = "pending" | "approved" | "rejected";
+export type FriendLinkSource = "manual" | "submission" | "imported";
+
+export type FriendLink = {
+  id: number;
+  name: string;
+  url: string;
+  description: string;
+  avatarUrl: string;
+  ownerName: string;
+  ownerEmail: string;
+  status: FriendLinkStatus;
+  source: FriendLinkSource;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  reviewedAt: string | null;
+};
+
+export type CreateFriendLinkInput = {
+  name: string;
+  url: string;
+  description?: string;
+  avatarUrl?: string;
+  ownerName?: string;
+  ownerEmail?: string;
+  status?: FriendLinkStatus;
+  source?: FriendLinkSource;
+  sortOrder?: number;
+};
+
+export type UpdateFriendLinkInput = Partial<CreateFriendLinkInput>;
+
 export type PostVersion = {
   id: number;
   postId: number;
@@ -223,6 +256,16 @@ export interface IDatabase {
   approveComment(id: number): Promise<boolean>;
   deleteComment(id: number): Promise<boolean>;
   getCommentCount(postSlug: string): Promise<number>;
+
+  /* 友链 */
+  getApprovedFriendLinks(): Promise<FriendLink[]>;
+  getAllFriendLinks(): Promise<FriendLink[]>;
+  createFriendLink(input: CreateFriendLinkInput): Promise<FriendLink>;
+  updateFriendLink(id: number, input: UpdateFriendLinkInput): Promise<FriendLink | null>;
+  approveFriendLink(id: number): Promise<boolean>;
+  rejectFriendLink(id: number): Promise<boolean>;
+  deleteFriendLink(id: number): Promise<boolean>;
+  importFriendLinks(input: CreateFriendLinkInput[]): Promise<number>;
 
   /* 系列 */
   getSeriesPosts(seriesSlug: string): Promise<{ slug: string; title: string; seriesOrder: number }[]>;


### PR DESCRIPTION
## Summary
- restore the moderated friend links feature that was previously deployed from dev
- add the public `/friends` page and admin `/admin/friends` moderation UI
- restore the `/api/friends` endpoints and D1/Turso/PostgreSQL adapter support
- include migration `0010_friend_links.sql`

## Context
The current production `main` deployment no longer exposes `/api/friends` because the friend-links commit lived on `dev` and was never merged into `main`. This PR applies only the standalone friend-links commit onto the latest `main`, preserving the merged RSS and sitemap fixes and recent dependency updates.

## Validation
- `npm run check`
- `npm run lint`
- `npm run build`
- cherry-pick onto latest `main` completed without conflicts

## Deployment follow-up
After merge, apply the D1 migration, deploy Worker and Pages, then verify `/api/friends` returns HTTP 200.
