### PR TITLE
feat(site): add timezone settings and series docs viewer

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -8,10 +8,12 @@ import { ProtectedRoute } from "@/components/protected-route";
 import { AdminLayout } from "@/components/admin-layout";
 import { CookieConsent, getCookieConsent } from "@/components/cookie-consent";
 import { trackPageview, bindUnloadTracker } from "@/lib/analytics";
+import { useSiteSettings } from "@/lib/site-settings";
 
 // 代码分割 (Code Splitting)
 const HomePage = lazy(() => import("@/pages/home").then((m) => ({ default: m.HomePage })));
 const PostPage = lazy(() => import("@/pages/post").then((m) => ({ default: m.PostPage })));
+const DocsPage = lazy(() => import("@/pages/docs").then((m) => ({ default: m.DocsPage })));
 const ArchivePage = lazy(() => import("@/pages/archive").then((m) => ({ default: m.ArchivePage })));
 const AboutPage = lazy(() => import("@/pages/about").then((m) => ({ default: m.AboutPage })));
 const FriendsPage = lazy(() => import("@/pages/friends").then((m) => ({ default: m.FriendsPage })));
@@ -86,6 +88,7 @@ function matchesPathPrefix(pathname: string, prefix: string) {
 
 export function App() {
   const [location] = useLocation();
+  const { settings, ready: siteSettingsReady } = useSiteSettings();
 
   // 访客埋点：路由变化触发 pageview，页面卸载触发 duration 上报
   useEffect(() => {
@@ -103,70 +106,66 @@ export function App() {
   // 注入自定义 header/footer 代码（需 Cookie 同意后加载第三方脚本）
   useEffect(() => {
     removeCustomInjection();
-    if (isAdminRoot) return undefined;
+    if (isAdminRoot || !siteSettingsReady) return undefined;
 
     let cancelled = false;
     let cleanupConsentListener: (() => void) | undefined;
 
-    fetch("/api/settings/public")
-      .then((r) => r.json())
-      .then((s) => {
-        if (cancelled) return;
-        syncDocumentBrand(s);
-        const hasThirdParty = (s.custom_header && /<script/i.test(s.custom_header))
-          || (s.custom_footer && /<script/i.test(s.custom_footer));
+    const s = settings;
+    syncDocumentBrand(s);
+    const hasThirdParty = (s.custom_header && /<script/i.test(s.custom_header))
+      || (s.custom_footer && /<script/i.test(s.custom_footer));
 
-        const inject = () => {
-          if (cancelled) return;
-          removeCustomInjection();
-          if (s.custom_header) {
-            const container = document.createElement("div");
-            container.id = "monolith-custom-header";
-            injectHtml(container, s.custom_header);
-            Array.from(container.childNodes).forEach((n) => {
-              if (n instanceof HTMLElement) n.dataset.monolithCustomInjection = "true";
-              document.head.appendChild(n);
-            });
-          }
-          if (s.custom_footer) {
-            const container = document.createElement("div");
-            container.id = "monolith-custom-footer";
-            container.dataset.monolithCustomInjection = "true";
-            injectHtml(container, s.custom_footer);
-            document.body.appendChild(container);
-          }
-        };
+    const inject = () => {
+      if (cancelled) return;
+      removeCustomInjection();
+      if (s.custom_header) {
+        const container = document.createElement("div");
+        container.id = "monolith-custom-header";
+        injectHtml(container, s.custom_header);
+        Array.from(container.childNodes).forEach((n) => {
+          if (n instanceof HTMLElement) n.dataset.monolithCustomInjection = "true";
+          document.head.appendChild(n);
+        });
+      }
+      if (s.custom_footer) {
+        const container = document.createElement("div");
+        container.id = "monolith-custom-footer";
+        container.dataset.monolithCustomInjection = "true";
+        injectHtml(container, s.custom_footer);
+        document.body.appendChild(container);
+      }
+    };
 
-        // 无第三方脚本则直接注入；有则等 Cookie 同意
-        if (!hasThirdParty) {
-          inject();
-        } else if (getCookieConsent()) {
-          inject();
-        } else {
-          window.addEventListener("cookie-consent-accepted", inject, { once: true });
-          cleanupConsentListener = () => window.removeEventListener("cookie-consent-accepted", inject);
-        }
-      })
-      .catch(() => {});
+    // 无第三方脚本则直接注入；有则等 Cookie 同意
+    if (!hasThirdParty) {
+      inject();
+    } else if (getCookieConsent()) {
+      inject();
+    } else {
+      window.addEventListener("cookie-consent-accepted", inject, { once: true });
+      cleanupConsentListener = () => window.removeEventListener("cookie-consent-accepted", inject);
+    }
     return () => {
       cancelled = true;
       cleanupConsentListener?.();
       removeCustomInjection();
     };
-  }, [isAdminRoot]);
+  }, [isAdminRoot, settings, siteSettingsReady]);
 
   return (
     <>
       <SearchOverlay />
 
       {/* ======== 1. 公开前台展示区 ======== */}
-      {isPublicPage && (
+      {isPublicPage && siteSettingsReady && (
         <>
           <Navbar />
           <main className="mx-auto w-full max-w-[1440px] px-[20px] lg:px-[40px] flex-1 flex flex-col">
             <Suspense fallback={<div className="p-8 flex justify-center text-zinc-500">Loading...</div>}>
               <Switch>
                 <Route path="/" component={HomePage} />
+                <Route path="/docs/:seriesSlug/:slug?" component={DocsPage} />
                 <Route path="/posts/:slug" component={PostPage} />
                 <Route path="/archive" component={ArchivePage} />
                 <Route path="/about" component={AboutPage} />
@@ -183,6 +182,12 @@ export function App() {
           <Footer />
           <CookieConsent />
         </>
+      )}
+
+      {isPublicPage && !siteSettingsReady && (
+        <main className="mx-auto flex w-full max-w-[1440px] flex-1 items-center justify-center px-[20px] lg:px-[40px]">
+          <div className="h-[180px] w-full max-w-[720px] animate-pulse rounded-md bg-card/20" aria-label="正在加载站点设置" />
+        </main>
       )}
 
       {/* ======== 2. 后台全屏编辑器区 ======== */}

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -35,15 +35,21 @@ const DynamicPage = lazy(() => import("@/pages/dynamic-page").then((m) => ({ def
 const NotFoundPage = lazy(() => import("@/pages/not-found").then((m) => ({ default: m.NotFoundPage })));
 
 
+const CUSTOM_INJECTION_SANITIZE_CONFIG = {
+  ADD_TAGS: ["script"],
+  ADD_ATTR: ["src", "async", "defer"],
+  FORBID_TAGS: ["style", "iframe", "object", "embed", "form"],
+  FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
+};
+
+function sanitizeCustomHtml(html: string) {
+  return DOMPurify.sanitize(html, CUSTOM_INJECTION_SANITIZE_CONFIG);
+}
+
 /** 将设置中的 HTML/JS 代码安全注入到页面（仅允许外部脚本 src） */
 function injectHtml(container: HTMLElement, html: string) {
   const temp = document.createElement("div");
-  temp.innerHTML = DOMPurify.sanitize(html, {
-    ADD_TAGS: ["script"],
-    ADD_ATTR: ["src", "async", "defer"],
-    FORBID_TAGS: ["style", "iframe", "object", "embed", "form"],
-    FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
-  });
+  temp.innerHTML = sanitizeCustomHtml(html);
   Array.from(temp.childNodes).forEach((node) => {
     if (node instanceof HTMLScriptElement) {
       if (!node.src) return; // 禁止内联脚本，只允许带 src 的外部脚本
@@ -55,6 +61,37 @@ function injectHtml(container: HTMLElement, html: string) {
     } else {
       container.appendChild(node.cloneNode(true));
     }
+  });
+}
+
+const EXTERNAL_RESOURCE_TAGS = new Set(["audio", "embed", "img", "link", "object", "script", "source", "track", "video"]);
+
+function isExternalResourceUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("data:") || trimmed.startsWith("blob:")) return false;
+
+  try {
+    const url = new URL(trimmed, window.location.href);
+    return (url.protocol === "http:" || url.protocol === "https:") && url.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function hasExternalResources(html: string) {
+  const temp = document.createElement("div");
+  temp.innerHTML = sanitizeCustomHtml(html);
+  return Array.from(temp.querySelectorAll<HTMLElement>("*")).some((node) => {
+    const tagName = node.tagName.toLowerCase();
+    if (EXTERNAL_RESOURCE_TAGS.has(tagName)) {
+      return ["src", "href", "poster", "data"].some((attribute) => {
+        const value = node.getAttribute(attribute);
+        return value ? isExternalResourceUrl(value) : false;
+      });
+    }
+
+    const style = node.getAttribute("style");
+    return Boolean(style && /url\(\s*["']?(?:https?:|\/\/)/i.test(style));
   });
 }
 
@@ -113,8 +150,8 @@ export function App() {
 
     const s = settings;
     syncDocumentBrand(s);
-    const hasThirdParty = (s.custom_header && /<script/i.test(s.custom_header))
-      || (s.custom_footer && /<script/i.test(s.custom_footer));
+    const hasExternalResource = [s.custom_header, s.custom_footer]
+      .some((html) => Boolean(html && hasExternalResources(html)));
 
     const inject = () => {
       if (cancelled) return;
@@ -137,8 +174,8 @@ export function App() {
       }
     };
 
-    // 无第三方脚本则直接注入；有则等 Cookie 同意
-    if (!hasThirdParty) {
+    // 无外部资源则直接注入；有则等 Cookie 同意，避免未同意时发起第三方请求
+    if (!hasExternalResource) {
       inject();
     } else if (getCookieConsent()) {
       inject();

--- a/client/src/components/article-card.tsx
+++ b/client/src/components/article-card.tsx
@@ -4,13 +4,11 @@ import type { PostMeta } from "@/lib/api";
 import { clampCardHeight, clampCardWidth, getArticleCardGridClass, getArticleCardImageMode } from "@/lib/card-layout";
 import { ArrowRight, CalendarDays, FolderOpen, Pin } from "lucide-react";
 import type { CSSProperties } from "react";
-
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleDateString("zh-CN", { year: "numeric", month: "long", day: "numeric" });
-}
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 export function ArticleCard({ post }: { post: PostMeta }) {
+  const { dateSettings } = useSiteSettings();
   const width = clampCardWidth(post.cardWidth);
   const height = clampCardHeight(post.cardHeight);
   const cover = post.coverImage?.trim() || "";
@@ -39,7 +37,7 @@ export function ArticleCard({ post }: { post: PostMeta }) {
       ))}
       <span className="inline-flex items-center gap-[4px] text-[12px] text-muted-foreground/55">
         <CalendarDays className="h-[12px] w-[12px]" />
-        {formatDate(post.createdAt)}
+        {formatSiteDate(post.createdAt, dateSettings)}
       </span>
     </div>
   );

--- a/client/src/components/comments.tsx
+++ b/client/src/components/comments.tsx
@@ -2,13 +2,8 @@ import { useEffect, useState, useCallback } from "react";
 import { Separator } from "@/components/ui/separator";
 import { fetchComments, submitComment, type CommentData } from "@/lib/api";
 import { MessageCircle, Send, User, ChevronDown, ChevronUp } from "lucide-react";
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("zh-CN", {
-    year: "numeric", month: "long", day: "numeric",
-    hour: "2-digit", minute: "2-digit",
-  });
-}
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 /** 通过昵称生成 DiceBear 头像 URL（不再传输邮箱） */
 function avatarUrl(name: string, size = 40): string {
@@ -18,6 +13,7 @@ function avatarUrl(name: string, size = 40): string {
 
 /* ── 单条评论 ──────────────────────────── */
 function CommentItem({ comment }: { comment: CommentData }) {
+  const { dateSettings } = useSiteSettings();
   return (
     <div className="group flex gap-[12px] py-[16px]">
       <div className="shrink-0">
@@ -31,7 +27,7 @@ function CommentItem({ comment }: { comment: CommentData }) {
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline gap-[8px] mb-[4px]">
           <span className="text-[14px] font-medium text-foreground">{comment.authorName}</span>
-          <span className="text-[12px] text-muted-foreground/50">{formatDate(comment.createdAt)}</span>
+          <span className="text-[12px] text-muted-foreground/50">{formatSiteDate(comment.createdAt, dateSettings)}</span>
         </div>
         <p className="text-[14px] leading-[1.7] text-muted-foreground/80 whitespace-pre-wrap break-words">
           {comment.content}

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -2,24 +2,18 @@ import { useEffect, useState } from "react";
 import { Link } from "wouter";
 import { AnimateIn } from "@/hooks/use-animate";
 import { fetchNavPages, type NavPage } from "@/lib/api";
+import { useSiteSettings } from "@/lib/site-settings";
 
 export function Footer() {
   const currentYear = new Date().getFullYear();
-  const [footerText, setFooterText] = useState("");
   const [navPages, setNavPages] = useState<NavPage[]>([]);
-
-  useEffect(() => {
-    fetch("/api/settings/public")
-      .then((r) => r.json())
-      .then((data) => setFooterText(data.footer_text || ""))
-      .catch(() => {});
-  }, []);
+  const { settings } = useSiteSettings();
 
   useEffect(() => {
     fetchNavPages().then(setNavPages);
   }, []);
 
-  const displayText = footerText || `© ${currentYear} Monolith. 使用 Hono + Vite 构建，部署于 Cloudflare 边缘。`;
+  const displayText = settings.footer_text || `© ${currentYear} Monolith. 使用 Hono + Vite 构建，部署于 Cloudflare 边缘。`;
 
   return (
     <footer className="app-footer mt-auto border-t border-border/40">

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -8,6 +8,7 @@ import { AdminGate } from "@/components/admin-gate";
 import { SearchTrigger } from "@/components/search";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { fetchNavPages, type NavPage } from "@/lib/api";
+import { useSiteSettings } from "@/lib/site-settings";
 
 const fixedStart = [{ href: "/", label: "首页" }];
 const fixedEnd = [
@@ -22,19 +23,10 @@ export function Navbar() {
   const [open, setOpen] = useState(false);
   const [gateOpen, setGateOpen] = useState(false);
   const [navPages, setNavPages] = useState<NavPage[]>([]);
-  const [brand, setBrand] = useState({ title: "Monolith", icon: "" });
+  const { settings } = useSiteSettings();
 
   useEffect(() => {
     fetchNavPages().then(setNavPages);
-    fetch("/api/settings/public")
-      .then((r) => r.json())
-      .then((settings: { site_title?: string; site_icon?: string }) => {
-        setBrand({
-          title: settings.site_title?.trim() || "Monolith",
-          icon: settings.site_icon?.trim() || "",
-        });
-      })
-      .catch(() => {});
   }, []);
 
   const navLinks = useMemo(
@@ -75,9 +67,9 @@ export function Navbar() {
             onDoubleClick={handleLogoDoubleClick}
           >
             <div className="relative flex h-[32px] w-[32px] shrink-0 items-center justify-center">
-              {brand.icon ? (
+              {settings.site_icon ? (
                 <img
-                  src={brand.icon}
+                  src={settings.site_icon}
                   alt=""
                   className="h-[28px] w-[28px] rounded-md object-cover transition-transform duration-300 group-hover:-translate-y-[2px]"
                 />
@@ -86,7 +78,7 @@ export function Navbar() {
               )}
             </div>
             <span className="max-w-[180px] truncate text-[18px] font-semibold tracking-[-0.03em] text-foreground sm:max-w-[240px]">
-              {brand.title}
+              {settings.site_title}
             </span>
           </Link>
 

--- a/client/src/components/series-nav.tsx
+++ b/client/src/components/series-nav.tsx
@@ -38,6 +38,9 @@ export function SeriesNav({ seriesSlug, currentSlug }: SeriesNavProps) {
             {currentIndex + 1} / {posts.length}
           </span>
         </button>
+        <Link href={`/docs/${seriesSlug}/${currentSlug}`} className="series-nav__docs-link" aria-label={`以文档模式打开系列 ${seriesSlug}`}>
+          文档模式
+        </Link>
       </div>
 
       {/* 可折叠目录 */}

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -1216,6 +1216,8 @@
 }
 
 .series-nav__header {
+  display: flex;
+  align-items: center;
   border-bottom: 1px solid oklch(0.35 0 0 / 30%);
 }
 
@@ -1223,7 +1225,8 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 12px 16px;
   background: none;
   border: none;
@@ -1253,6 +1256,29 @@
   font-size: 11px;
   opacity: 0.5;
   font-variant-numeric: tabular-nums;
+}
+
+.series-nav__docs-link {
+  flex-shrink: 0;
+  margin-right: 12px;
+  padding: 5px 8px;
+  border: 1px solid oklch(0.55 0 0 / 24%);
+  border-radius: 5px;
+  color: oklch(0.7 0 0);
+  font-size: 11px;
+  text-decoration: none;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+}
+
+.series-nav__docs-link:hover {
+  color: oklch(0.9 0 0);
+  border-color: oklch(0.75 0 0 / 42%);
+  background: oklch(0.3 0 0 / 20%);
+}
+
+.series-nav__docs-link:focus-visible {
+  outline: 2px solid oklch(0.75 0 0 / 70%);
+  outline-offset: 2px;
 }
 
 /* 折叠目录 */
@@ -1373,6 +1399,17 @@
 
 [data-theme="light"] .series-nav__toggle:hover {
   color: oklch(0.15 0 0);
+}
+
+[data-theme="light"] .series-nav__docs-link {
+  color: oklch(0.4 0 0);
+  border-color: oklch(0.55 0 0 / 28%);
+}
+
+[data-theme="light"] .series-nav__docs-link:hover {
+  color: oklch(0.15 0 0);
+  border-color: oklch(0.35 0 0 / 42%);
+  background: oklch(0.92 0 0 / 50%);
 }
 
 [data-theme="light"] .series-nav__title {

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -1412,6 +1412,10 @@
   background: oklch(0.92 0 0 / 50%);
 }
 
+[data-theme="light"] .series-nav__docs-link:focus-visible {
+  outline-color: oklch(0.35 0 0);
+}
+
 [data-theme="light"] .series-nav__title {
   color: oklch(0.45 0.12 220);
 }

--- a/client/src/lib/date-format.ts
+++ b/client/src/lib/date-format.ts
@@ -32,9 +32,12 @@ export function formatSiteDate(value: string | null | undefined, settings: SiteD
     day: "numeric",
   };
 
-  if (settings.datePrecision === "datetime") {
+  if (settings.datePrecision === "datetime" || settings.datePrecision === "datetime_seconds") {
     options.hour = "2-digit";
     options.minute = "2-digit";
+  }
+  if (settings.datePrecision === "datetime_seconds") {
+    options.second = "2-digit";
   }
 
   try {

--- a/client/src/lib/date-format.ts
+++ b/client/src/lib/date-format.ts
@@ -1,0 +1,67 @@
+import type { SiteDateSettings } from "@/lib/site-settings";
+
+function parseSiteDate(value: string): Date {
+  // SQLite datetime('now') 返回 `YYYY-MM-DD HH:mm:ss`，语义是 UTC，
+  // 但浏览器会把没有时区标记的日期时间误解为本地时间。
+  const isSqliteDateTime = value.length === 19
+    && (value[10] === " " || value[10] === "T")
+    && value[4] === "-"
+    && value[7] === "-"
+    && value[13] === ":"
+    && value[16] === ":"
+    && [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18].every((index) => {
+      const code = value.charCodeAt(index);
+      return code >= 48 && code <= 57;
+    });
+  const normalized = isSqliteDateTime
+    ? `${value.replace(" ", "T")}Z`
+    : value;
+  return new Date(normalized);
+}
+
+export function formatSiteDate(value: string | null | undefined, settings: SiteDateSettings): string {
+  if (!value) return "";
+
+  const date = parseSiteDate(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const options: Intl.DateTimeFormatOptions = {
+    timeZone: settings.timezone || "Asia/Shanghai",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+
+  if (settings.datePrecision === "datetime") {
+    options.hour = "2-digit";
+    options.minute = "2-digit";
+  }
+
+  try {
+    return new Intl.DateTimeFormat("zh-CN", options).format(date);
+  } catch {
+    return new Intl.DateTimeFormat("zh-CN", {
+      ...options,
+      timeZone: "Asia/Shanghai",
+    }).format(date);
+  }
+}
+
+export function getSiteDateYear(value: string | null | undefined, settings: SiteDateSettings): string {
+  if (!value) return "";
+
+  const date = parseSiteDate(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  try {
+    return new Intl.DateTimeFormat("en", {
+      timeZone: settings.timezone || "Asia/Shanghai",
+      year: "numeric",
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat("en", {
+      timeZone: "Asia/Shanghai",
+      year: "numeric",
+    }).format(date);
+  }
+}

--- a/client/src/lib/site-settings.tsx
+++ b/client/src/lib/site-settings.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 
-export type SiteDatePrecision = "date" | "datetime";
+export type SiteDatePrecision = "date" | "datetime" | "datetime_seconds";
 
 export type SiteDateSettings = {
   timezone: string;
@@ -70,6 +70,7 @@ type SiteSettingsContextValue = {
 const SiteSettingsContext = createContext<SiteSettingsContextValue | null>(null);
 
 function normalizeDatePrecision(value: string): SiteDatePrecision {
+  if (value === "datetime_seconds") return "datetime_seconds";
   return value === "datetime" ? "datetime" : "date";
 }
 
@@ -79,7 +80,10 @@ export function SiteSettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("/api/settings/public")
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 10_000);
+
+    fetch("/api/settings/public", { signal: controller.signal })
       .then((response) => {
         if (!response.ok) throw new Error("settings request failed");
         return response.json() as Promise<Partial<PublicSiteSettings>>;
@@ -90,11 +94,14 @@ export function SiteSettingsProvider({ children }: { children: ReactNode }) {
       })
       .catch(() => {})
       .finally(() => {
+        window.clearTimeout(timeoutId);
         if (!cancelled) setReady(true);
       });
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timeoutId);
+      controller.abort();
     };
   }, []);
 

--- a/client/src/lib/site-settings.tsx
+++ b/client/src/lib/site-settings.tsx
@@ -1,0 +1,117 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+export type SiteDatePrecision = "date" | "datetime";
+
+export type SiteDateSettings = {
+  timezone: string;
+  datePrecision: SiteDatePrecision;
+};
+
+export type PublicSiteSettings = {
+  site_title: string;
+  site_description: string;
+  site_tagline: string;
+  hero_kicker: string;
+  hero_subtitle: string;
+  hero_description: string;
+  hero_actions: string;
+  hero_topics: string;
+  site_icon: string;
+  site_og_image: string;
+  author_name: string;
+  author_title: string;
+  author_bio: string;
+  author_avatar: string;
+  github_url: string;
+  twitter_url: string;
+  email: string;
+  social_links: string;
+  footer_text: string;
+  rss_enabled: string;
+  custom_header: string;
+  custom_footer: string;
+  site_timezone: string;
+  date_precision: string;
+};
+
+const DEFAULT_SITE_SETTINGS: PublicSiteSettings = {
+  site_title: "Monolith",
+  site_description: "书写代码、设计与边缘计算的个人博客。",
+  site_tagline: "在秩序与混沌的交界处，寻找属于自己的巨石碑。",
+  hero_kicker: "EDGE JOURNAL / CODE ARCHIVE",
+  hero_subtitle: "技术写作、系统设计与边缘实践的索引页",
+  hero_description: "用更冷静的网格整理长期主题：前端架构、设计系统、边缘计算与工程排障。",
+  hero_actions: "",
+  hero_topics: "",
+  site_icon: "",
+  site_og_image: "",
+  author_name: "Monolith",
+  author_title: "独立开发者",
+  author_bio: "",
+  author_avatar: "",
+  github_url: "",
+  twitter_url: "",
+  email: "",
+  social_links: "",
+  footer_text: "",
+  rss_enabled: "true",
+  custom_header: "",
+  custom_footer: "",
+  site_timezone: "Asia/Shanghai",
+  date_precision: "date",
+};
+
+type SiteSettingsContextValue = {
+  settings: PublicSiteSettings;
+  dateSettings: SiteDateSettings;
+  ready: boolean;
+};
+
+const SiteSettingsContext = createContext<SiteSettingsContextValue | null>(null);
+
+function normalizeDatePrecision(value: string): SiteDatePrecision {
+  return value === "datetime" ? "datetime" : "date";
+}
+
+export function SiteSettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<PublicSiteSettings>(DEFAULT_SITE_SETTINGS);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/settings/public")
+      .then((response) => {
+        if (!response.ok) throw new Error("settings request failed");
+        return response.json() as Promise<Partial<PublicSiteSettings>>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setSettings((previous) => ({ ...previous, ...data }));
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setReady(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo<SiteSettingsContextValue>(() => ({
+    settings,
+    dateSettings: {
+      timezone: settings.site_timezone || "Asia/Shanghai",
+      datePrecision: normalizeDatePrecision(settings.date_precision),
+    },
+    ready,
+  }), [ready, settings]);
+
+  return <SiteSettingsContext.Provider value={value}>{children}</SiteSettingsContext.Provider>;
+}
+
+export function useSiteSettings(): SiteSettingsContextValue {
+  const context = useContext(SiteSettingsContext);
+  if (!context) throw new Error("useSiteSettings must be used within SiteSettingsProvider");
+  return context;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { App } from "./app";
 import "./globals.css";
 import { registerSW } from "virtual:pwa-register";
+import { SiteSettingsProvider } from "@/lib/site-settings";
 
 const updateSW = registerSW({
   onNeedRefresh() {
@@ -17,6 +18,8 @@ const updateSW = registerSW({
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <SiteSettingsProvider>
+      <App />
+    </SiteSettingsProvider>
   </React.StrictMode>
 );

--- a/client/src/pages/admin/backup.tsx
+++ b/client/src/pages/admin/backup.tsx
@@ -19,6 +19,8 @@ import {
 } from "lucide-react";
 import { getToken } from "@/lib/api";
 import { platforms, type ImportResult, type PlatformInfo } from "@/lib/importers";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 type RestoreMode = "merge" | "overwrite";
 type RiskLevel = "low" | "medium" | "high";
@@ -84,7 +86,7 @@ function formatSize(bytes: number): string {
   return `${(bytes / 1048576).toFixed(1)} MB`;
 }
 
-function timeAgo(value: string): string {
+function timeAgo(value: string, dateSettings: Parameters<typeof formatSiteDate>[1]): string {
   const diff = Date.now() - new Date(value).getTime();
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return "刚刚";
@@ -92,7 +94,7 @@ function timeAgo(value: string): string {
   const hours = Math.floor(mins / 60);
   if (hours < 24) return `${hours} 小时前`;
   const days = Math.floor(hours / 24);
-  return days < 30 ? `${days} 天前` : new Date(value).toLocaleDateString("zh-CN");
+  return days < 30 ? `${days} 天前` : formatSiteDate(value, dateSettings);
 }
 
 function riskCopy(riskLevel: RiskLevel): { label: string; className: string } {
@@ -108,6 +110,7 @@ function sampleStatusCopy(status: "create" | "update" | "skip") {
 }
 
 export function AdminBackup() {
+  const { dateSettings } = useSiteSettings();
   const [message, setMessage] = useState<Toast>({ text: "", type: "" });
   const [r2Backups, setR2Backups] = useState<R2Backup[]>([]);
   const [r2Loading, setR2Loading] = useState(false);
@@ -418,7 +421,7 @@ export function AdminBackup() {
       </div>
 
       <div className="mb-[20px] grid gap-[8px] md:grid-cols-4">
-        <StatusCard label="最近恢复点" value={latestBackup ? timeAgo(latestBackup.uploaded) : "暂无"} detail={latestBackup ? latestBackup.name : "请先创建 R2 或本地备份"} />
+        <StatusCard label="最近恢复点" value={latestBackup ? timeAgo(latestBackup.uploaded, dateSettings) : "暂无"} detail={latestBackup ? latestBackup.name : "请先创建 R2 或本地备份"} />
         <StatusCard label="R2 备份数" value={String(r2Backups.length)} detail={`累计 ${formatSize(totalBackupSize)}`} />
         <StatusCard label="WebDAV 状态" value={webdavConfig.url ? "已配置" : "未配置"} detail={webdavConfig.url || "建议配置第二远程副本"} />
         <StatusCard label="默认恢复策略" value={restoreMode === "merge" ? "合并" : "覆盖"} detail={restoreMode === "merge" ? "跳过已有文章" : "更新已有文章"} />
@@ -505,7 +508,7 @@ export function AdminBackup() {
                         <p className="mt-[2px] text-[11px] text-muted-foreground/35">{backup.key}</p>
                       </div>
                       <span className="text-[12px] text-muted-foreground/55">{formatSize(backup.size)}</span>
-                      <span className="text-[12px] text-muted-foreground/55">{timeAgo(backup.uploaded)}</span>
+                      <span className="text-[12px] text-muted-foreground/55">{timeAgo(backup.uploaded, dateSettings)}</span>
                       <div className="flex justify-end gap-[6px]">
                         <IconButton
                           label="预检并恢复"

--- a/client/src/pages/admin/comments.tsx
+++ b/client/src/pages/admin/comments.tsx
@@ -9,17 +9,13 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("zh-CN", {
-    year: "numeric", month: "short", day: "numeric",
-    hour: "2-digit", minute: "2-digit",
-  });
-}
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 type FilterType = "all" | "pending" | "approved";
 
 export function AdminComments() {
+  const { dateSettings } = useSiteSettings();
   const [comments, setComments] = useState<AdminComment[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<FilterType>("all");
@@ -204,7 +200,7 @@ export function AdminComments() {
                       {comment.postTitle}
                     </Link>
                     <span className="text-border/40">·</span>
-                    <span>{formatDate(comment.createdAt)}</span>
+                    <span>{formatSiteDate(comment.createdAt, dateSettings)}</span>
                   </div>
                 </div>
 

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -3,8 +3,10 @@ import { Link } from "wouter";
 import { fetchAdminPosts, deletePost, batchOperatePosts, fetchViewStats, type Post, type ViewStats } from "@/lib/api";
 import { Plus, Edit, Trash2, Eye, FileText, Clock, Search, ExternalLink, Globe, CheckSquare, Square, EyeOff, TrendingUp, ArrowRight, BarChart3 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
-function timeAgo(d: string): string {
+function timeAgo(d: string, dateSettings: Parameters<typeof formatSiteDate>[1]): string {
   const diff = Date.now() - new Date(d).getTime();
   const mins = Math.floor(diff / 60000);
   if (mins < 1) return "刚刚";
@@ -13,12 +15,13 @@ function timeAgo(d: string): string {
   if (hours < 24) return `${hours} 小时前`;
   const days = Math.floor(hours / 24);
   if (days < 30) return `${days} 天前`;
-  return new Date(d).toLocaleDateString("zh-CN", { year: "numeric", month: "short", day: "numeric" });
+  return formatSiteDate(d, dateSettings);
 }
 
 type FilterType = "all" | "published" | "draft";
 
 export function AdminDashboard() {
+  const { dateSettings } = useSiteSettings();
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState<string | null>(null);
@@ -311,7 +314,7 @@ export function AdminDashboard() {
                       {post.pinned && <Badge variant="outline" className="h-[16px] rounded-[3px] px-[4px] text-[9px] font-medium text-amber-500/80 border-amber-500/20 bg-amber-500/5">置顶</Badge>}
                     </div>
                     <div className="flex items-center gap-[8px] text-[11px] text-muted-foreground/30">
-                      <span>{timeAgo(post.updatedAt || post.createdAt)}</span>
+                      <span>{timeAgo(post.updatedAt || post.createdAt, dateSettings)}</span>
                       <span className="flex items-center gap-[2px] font-mono"><Eye className="h-[9px] w-[9px]" />{(post.viewCount ?? 0).toLocaleString()}</span>
                       {post.tags.length > 0 && <span>{post.tags.slice(0, 2).join(" · ")}</span>}
                     </div>

--- a/client/src/pages/admin/editor.tsx
+++ b/client/src/pages/admin/editor.tsx
@@ -7,6 +7,8 @@ import { Save, Eye, EyeOff, Upload, Image, ChevronDown, ChevronUp, Bold, Italic,
 import { Link } from "wouter";
 import Editor, { type Monaco } from "@monaco-editor/react";
 import type * as MonacoTypes from "monaco-editor";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 /** 注册 Monolith 暗色主题 — 暗夜琥珀：黑 + 金点缀 */
 function handleEditorWillMount(monaco: Monaco) {
@@ -110,6 +112,7 @@ const CARD_LAYOUT_PRESETS = [
 ];
 
 export function AdminEditor() {
+  const { dateSettings } = useSiteSettings();
   const params = useParams<{ slug?: string }>();
   const [, setLocation] = useLocation();
   const isEdit = !!params.slug;
@@ -280,7 +283,7 @@ export function AdminEditor() {
 
   const handleRestore = async (version: PostVersion) => {
     if (!params.slug) return;
-    if (!confirm(`确定要恢复到 ${new Date(version.createdAt).toLocaleString()} 的版本吗？当前未保存的修改将丢失。`)) return;
+    if (!confirm(`确定要恢复到 ${formatSiteDate(version.createdAt, dateSettings)} 的版本吗？当前未保存的修改将丢失。`)) return;
     setRestoring(true);
     try {
       const { post } = await restorePostVersion(params.slug, version.id);
@@ -1044,7 +1047,7 @@ export function AdminEditor() {
                 versions.map((v, i) => (
                   <div key={v.id} className="group flex items-center justify-between rounded-md border border-border/15 bg-card/5 p-[14px] transition-all hover:border-border/35 hover:bg-foreground/[0.035]">
                     <div>
-                      <div className="text-[14px] font-medium text-foreground/90 mb-[4px]">{new Date(v.createdAt).toLocaleString()}</div>
+                      <div className="text-[14px] font-medium text-foreground/90 mb-[4px]">{formatSiteDate(v.createdAt, dateSettings)}</div>
                       <div className="text-[12px] text-muted-foreground/50">
                         {v.content.length} 字符
                         {i === 0 && <span className="ml-[8px] text-[10px] bg-emerald-500/10 text-emerald-400 px-[6px] py-[2px] rounded-[4px]">最新快照</span>}

--- a/client/src/pages/admin/friends.tsx
+++ b/client/src/pages/admin/friends.tsx
@@ -23,6 +23,8 @@ import {
   type FriendLinkStatus,
 } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 type FilterType = "all" | FriendLinkStatus;
 type FormState = {
@@ -57,17 +59,6 @@ const STATUS_META: Record<FriendLinkStatus, { label: string; className: string }
 
 const inputClass = "h-[36px] w-full rounded-md border border-border/25 bg-background/30 px-[10px] text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/30 focus:border-foreground/20";
 
-function formatDate(value?: string | null) {
-  if (!value) return "未记录";
-  return new Date(value).toLocaleDateString("zh-CN", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
 function toForm(link: FriendLink): FormState {
   return {
     id: link.id,
@@ -83,6 +74,7 @@ function toForm(link: FriendLink): FormState {
 }
 
 export function AdminFriends() {
+  const { dateSettings } = useSiteSettings();
   const [links, setLinks] = useState<FriendLink[]>([]);
   const [filter, setFilter] = useState<FilterType>("all");
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
@@ -304,7 +296,7 @@ export function AdminFriends() {
                             {link.url}
                           </a>
                           <span>排序 {link.sortOrder}</span>
-                          <span>{formatDate(link.createdAt)}</span>
+                          <span>{link.createdAt ? formatSiteDate(link.createdAt, dateSettings) : "未记录"}</span>
                         </div>
                       </div>
                       <div className="flex shrink-0 items-center gap-[2px] md:opacity-0 md:transition-opacity md:group-hover:opacity-100">

--- a/client/src/pages/admin/guestbook.tsx
+++ b/client/src/pages/admin/guestbook.tsx
@@ -14,20 +14,13 @@ import {
   type GuestbookMessage,
 } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 type FilterType = "all" | "pending" | "approved";
 
-function formatDate(value: string) {
-  return new Date(value).toLocaleDateString("zh-CN", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
 export function AdminGuestbook() {
+  const { dateSettings } = useSiteSettings();
   const [messages, setMessages] = useState<GuestbookMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -207,7 +200,7 @@ export function AdminGuestbook() {
                   <p className="mb-[8px] whitespace-pre-wrap break-words text-[13px] leading-[1.7] text-muted-foreground/72">
                     {message.content}
                   </p>
-                  <span className="text-[11px] text-muted-foreground/30">{formatDate(message.createdAt)}</span>
+                  <span className="text-[11px] text-muted-foreground/30">{formatSiteDate(message.createdAt, dateSettings)}</span>
                 </div>
                 <div className="flex shrink-0 items-center gap-[2px] md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:group-focus-within:opacity-100">
                   {!message.approved && (

--- a/client/src/pages/admin/media.tsx
+++ b/client/src/pages/admin/media.tsx
@@ -9,18 +9,13 @@ import {
   Trash2, Image as ImageIcon, Grid, List, Upload,
   Copy, Check, X, Eye, ImageDown,
 } from "lucide-react";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("zh-CN", {
-    year: "numeric", month: "short", day: "numeric",
-    hour: "2-digit", minute: "2-digit",
-  });
 }
 
 function isImageFile(name: string): boolean {
@@ -30,6 +25,7 @@ function isImageFile(name: string): boolean {
 type ViewMode = "grid" | "list";
 
 export function AdminMedia() {
+  const { dateSettings } = useSiteSettings();
   const [media, setMedia] = useState<MediaItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
@@ -344,7 +340,7 @@ export function AdminMedia() {
               {/* 文件信息 */}
               <div className="flex-1 min-w-0">
                 <p className="text-[13px] text-foreground truncate">{item.name}</p>
-                <p className="text-[11px] text-muted-foreground/30">{formatSize(item.size)} · {formatDate(item.uploaded)}</p>
+                <p className="text-[11px] text-muted-foreground/30">{formatSize(item.size)} · {formatSiteDate(item.uploaded, dateSettings)}</p>
               </div>
 
               {/* 操作 */}
@@ -400,7 +396,7 @@ export function AdminMedia() {
             <div className="mt-[12px] flex items-center justify-between">
               <div>
                 <p className="text-[14px] text-foreground">{preview.name}</p>
-                <p className="text-[12px] text-muted-foreground/40">{formatSize(preview.size)} · {formatDate(preview.uploaded)}</p>
+                <p className="text-[12px] text-muted-foreground/40">{formatSize(preview.size)} · {formatSiteDate(preview.uploaded, dateSettings)}</p>
               </div>
               <div className="flex gap-[4px]">
                 <button

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, type ReactNode } from "react";
 import { getToken } from "@/lib/api";
-import { Save, Globe, User, Link2, ToggleLeft, ToggleRight, Code, Rss, Plus, Trash2, GripVertical, Home, Eye, Search, CheckCircle2, AlertTriangle } from "lucide-react";
+import { Save, Globe, User, Link2, ToggleLeft, ToggleRight, Code, Rss, Plus, Trash2, GripVertical, Home, Eye, Search, CheckCircle2, AlertTriangle, Clock3 } from "lucide-react";
 
 type Settings = {
   site_title: string;
@@ -25,6 +25,8 @@ type Settings = {
   rss_enabled: string;
   custom_header: string;
   custom_footer: string;
+  site_timezone: string;
+  date_precision: string;
 };
 
 const defaultSettings: Settings = {
@@ -58,6 +60,8 @@ const defaultSettings: Settings = {
   rss_enabled: "true",
   custom_header: "",
   custom_footer: "",
+  site_timezone: "Asia/Shanghai",
+  date_precision: "date",
 };
 
 type TabId = "identity" | "home" | "profile" | "social" | "advanced";
@@ -448,6 +452,28 @@ export function AdminSettings() {
                   <SettingField label="站点图标 URL" value={settings.site_icon} onChange={(v) => updateSetting("site_icon", v)} placeholder="https://example.com/favicon.png" mono hint="用于浏览器 favicon 和左上角后台暗门入口，留空则使用默认图标。" />
                   <SettingField label="社交分享图 URL" value={settings.site_og_image} onChange={(v) => updateSetting("site_og_image", v)} placeholder="https://example.com/og-image.png" mono hint="用于首页 Open Graph / Twitter Card，留空则使用默认 og-default.png。" />
                   <SettingField label="页脚文本" value={settings.footer_text} onChange={(v) => updateSetting("footer_text", v)} placeholder="© 2026 ..." hint="显示在全站页脚，支持纯文本。" />
+                  <div className="grid gap-[12px] sm:grid-cols-2">
+                    <label className="block">
+                      <span className="mb-[6px] flex items-center gap-[6px] text-[11px] font-medium text-muted-foreground/50"><Clock3 className="h-[12px] w-[12px]" />站点时区</span>
+                      <select value={settings.site_timezone} onChange={(e) => updateSetting("site_timezone", e.target.value)} className="settings-input h-[40px] w-full">
+                        <option value="Asia/Shanghai">Asia/Shanghai（中国标准时间）</option>
+                        <option value="UTC">UTC（协调世界时）</option>
+                        <option value="Asia/Tokyo">Asia/Tokyo（日本标准时间）</option>
+                        <option value="America/Los_Angeles">America/Los_Angeles（太平洋时间）</option>
+                        <option value="America/New_York">America/New_York（东部时间）</option>
+                        <option value="Europe/London">Europe/London（英国时间）</option>
+                      </select>
+                      <span className="mt-[6px] block text-[11px] leading-[1.5] text-muted-foreground/40">公开文章、评论和留言时间统一使用此 IANA 时区。</span>
+                    </label>
+                    <label className="block">
+                      <span className="mb-[6px] flex items-center gap-[6px] text-[11px] font-medium text-muted-foreground/50">日期显示精度</span>
+                      <select value={settings.date_precision} onChange={(e) => updateSetting("date_precision", e.target.value)} className="settings-input h-[40px] w-full">
+                        <option value="date">仅日期</option>
+                        <option value="datetime">日期 + 时分</option>
+                      </select>
+                      <span className="mt-[6px] block text-[11px] leading-[1.5] text-muted-foreground/40">默认仅显示日期，适合保持当前首页与归档的密度。</span>
+                    </label>
+                  </div>
                 </div>
               </div>
 

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -470,6 +470,7 @@ export function AdminSettings() {
                       <select value={settings.date_precision} onChange={(e) => updateSetting("date_precision", e.target.value)} className="settings-input h-[40px] w-full">
                         <option value="date">仅日期</option>
                         <option value="datetime">日期 + 时分</option>
+                        <option value="datetime_seconds">日期 + 时分秒</option>
                       </select>
                       <span className="mt-[6px] block text-[11px] leading-[1.5] text-muted-foreground/40">默认仅显示日期，适合保持当前首页与归档的密度。</span>
                     </label>

--- a/client/src/pages/archive.tsx
+++ b/client/src/pages/archive.tsx
@@ -5,12 +5,11 @@ import { Separator } from "@/components/ui/separator";
 import { fetchPosts, type PostMeta } from "@/lib/api";
 import { AnimateIn } from "@/hooks/use-animate";
 import { SeoHead } from "@/components/seo-head";
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("zh-CN", { year: "numeric", month: "long", day: "numeric" });
-}
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate, getSiteDateYear } from "@/lib/date-format";
 
 export function ArchivePage() {
+  const { dateSettings } = useSiteSettings();
   const searchString = useSearch();
   const [posts, setPosts] = useState<PostMeta[]>([]);
   const [loading, setLoading] = useState(true);
@@ -40,7 +39,7 @@ export function ArchivePage() {
 
   const grouped = new Map<string, PostMeta[]>();
   for (const post of visiblePosts) {
-    const year = new Date(post.createdAt).getFullYear().toString();
+    const year = getSiteDateYear(post.createdAt, dateSettings);
     if (!grouped.has(year)) grouped.set(year, []);
     grouped.get(year)!.push(post);
   }
@@ -110,7 +109,7 @@ export function ArchivePage() {
             <div className="overflow-hidden rounded-md border border-border/16 bg-background/22">
               {grouped.get(year)!.map((post) => (
                 <Link key={post.slug} href={`/posts/${post.slug}`} className="group grid min-h-[52px] grid-cols-[86px_minmax(0,1fr)] items-center gap-[12px] border-b border-border/10 px-[12px] py-[10px] transition-all duration-200 last:border-b-0 hover:bg-accent/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring sm:grid-cols-[106px_minmax(0,1fr)_160px]">
-                  <span className="shrink-0 font-mono text-[12px] tabular-nums text-muted-foreground/40">{formatDate(post.createdAt).replace(/\d{4}年/, "")}</span>
+                  <span className="shrink-0 font-mono text-[12px] tabular-nums text-muted-foreground/40">{formatSiteDate(post.createdAt, dateSettings).replace(/\d{4}年/, "")}</span>
                   <span className="min-w-0 truncate text-[15px] text-foreground transition-colors duration-200 group-hover:text-foreground/82">{post.title}</span>
                   <div className="ml-auto hidden shrink-0 gap-[4px] sm:flex">
                     {post.tags.slice(0, 1).map((tag) => (

--- a/client/src/pages/docs.tsx
+++ b/client/src/pages/docs.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "wouter";
+import { BookOpen, ChevronLeft, ChevronRight, List, Menu } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { SeoHead } from "@/components/seo-head";
+import { TableOfContents, ReadingProgressBar } from "@/components/toc";
+import { fetchPost, fetchSeriesPosts, type Post, type SeriesPost } from "@/lib/api";
+import { extractHeadings, renderMarkdown, type TocHeading } from "@/lib/markdown";
+import { formatSiteDate } from "@/lib/date-format";
+import { useSiteSettings } from "@/lib/site-settings";
+
+function SeriesDirectory({ seriesSlug, currentSlug, posts, mobile = false }: {
+  seriesSlug: string;
+  currentSlug: string;
+  posts: SeriesPost[];
+  mobile?: boolean;
+}) {
+  return (
+    <nav aria-label={`${seriesSlug} 文档目录`} className={mobile ? "space-y-[4px]" : "sticky top-[88px] space-y-[10px]"}>
+      <div className="flex items-center gap-[8px] text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/45">
+        <List className="h-[13px] w-[13px]" />
+        <span>文档目录</span>
+        <span className="ml-auto font-mono text-[10px] text-muted-foreground/35">{posts.length}</span>
+      </div>
+      <ol className="space-y-[2px] border-l border-border/20 pl-[10px]">
+        {posts.map((item, index) => {
+          const active = item.slug === currentSlug;
+          return (
+            <li key={item.slug}>
+              {active ? (
+                <span className="flex min-h-[40px] items-start gap-[8px] rounded-md bg-card/45 px-[10px] py-[8px] text-[13px] font-medium text-foreground" aria-current="page">
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/45">{String(index + 1).padStart(2, "0")}</span>
+                  <span className="min-w-0 leading-[1.45]">{item.title}</span>
+                </span>
+              ) : (
+                <Link href={`/docs/${seriesSlug}/${item.slug}`} className="flex min-h-[40px] items-start gap-[8px] rounded-md px-[10px] py-[8px] text-[13px] text-muted-foreground/70 transition-colors hover:bg-accent/30 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/35">{String(index + 1).padStart(2, "0")}</span>
+                  <span className="min-w-0 leading-[1.45]">{item.title}</span>
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+export function DocsPage() {
+  const params = useParams<{ seriesSlug: string; slug?: string }>();
+  const { dateSettings, settings } = useSiteSettings();
+  const [seriesPosts, setSeriesPosts] = useState<SeriesPost[]>([]);
+  const [post, setPost] = useState<Post | null>(null);
+  const [headings, setHeadings] = useState<TocHeading[]>([]);
+  const [htmlContent, setHtmlContent] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!params.seriesSlug) return;
+    let cancelled = false;
+    setLoading(true);
+    setError("");
+    setPost(null);
+
+    fetchSeriesPosts(params.seriesSlug)
+      .then(async (items) => {
+        if (cancelled) return;
+        setSeriesPosts(items);
+        const currentSlug = params.slug && items.some((item) => item.slug === params.slug)
+          ? params.slug
+          : items[0]?.slug;
+        if (!currentSlug) throw new Error("文档系列不存在");
+        const currentPost = await fetchPost(currentSlug);
+        if (!cancelled) setPost(currentPost);
+      })
+      .catch(() => {
+        if (!cancelled) setError("文档系列加载失败，请检查链接或稍后重试。");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [params.seriesSlug, params.slug]);
+
+  useEffect(() => {
+    if (!post) {
+      setHeadings([]);
+      setHtmlContent("");
+      return;
+    }
+    setHeadings(extractHeadings(post.content));
+    setHtmlContent(renderMarkdown(post.content));
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+  }, [post]);
+
+  const currentIndex = useMemo(
+    () => seriesPosts.findIndex((item) => item.slug === post?.slug),
+    [post?.slug, seriesPosts],
+  );
+  const previous = currentIndex > 0 ? seriesPosts[currentIndex - 1] : null;
+  const next = currentIndex >= 0 && currentIndex < seriesPosts.length - 1 ? seriesPosts[currentIndex + 1] : null;
+  const seriesTitle = params.seriesSlug || "文档系列";
+
+  if (loading) {
+    return (
+      <div className="mx-auto w-full max-w-[1120px] px-[16px] py-[40px] sm:px-[20px] sm:py-[56px]">
+        <div className="animate-pulse space-y-[16px]">
+          <div className="h-[18px] w-[180px] rounded-md bg-card/30" />
+          <div className="h-[42px] w-3/4 rounded-md bg-card/30" />
+          <div className="h-[18px] w-full rounded-md bg-card/30" />
+          <div className="h-[18px] w-5/6 rounded-md bg-card/30" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !post) {
+    return (
+      <div className="mx-auto flex w-full max-w-[720px] flex-1 items-center justify-center px-[20px] py-[80px] text-center">
+        <div>
+          <p className="text-[18px] font-medium text-foreground/80">{error || "文档未找到"}</p>
+          <Link href="/" className="mt-[14px] inline-flex min-h-[44px] items-center rounded-md border border-border/25 px-[14px] text-[13px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">返回首页</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SeoHead
+        title={`${seriesTitle} · ${post.title}`}
+        siteName={settings.site_title}
+        description={post.excerpt || `${seriesTitle} 文档系列`}
+        url={`/docs/${params.seriesSlug}/${post.slug}`}
+        type="article"
+        publishedTime={post.createdAt}
+        modifiedTime={post.updatedAt}
+        tags={post.tags}
+        breadcrumbs={[
+          { name: "首页", url: "/" },
+          { name: "文档", url: `/docs/${params.seriesSlug}` },
+          { name: post.title, url: `/docs/${params.seriesSlug}/${post.slug}` },
+        ]}
+      />
+      <ReadingProgressBar />
+
+      <div className="mx-auto w-full max-w-[1180px] px-[16px] sm:px-[20px] lg:px-[32px]">
+        <div className="flex items-center gap-[8px] py-[18px] text-[12px] text-muted-foreground/50">
+          <Link href="/" className="transition-colors hover:text-foreground">首页</Link>
+          <ChevronRight className="h-[12px] w-[12px]" />
+          <span className="text-muted-foreground/70">文档</span>
+          <ChevronRight className="h-[12px] w-[12px]" />
+          <span className="truncate text-foreground/75">{seriesTitle}</span>
+        </div>
+
+        <div className="mb-[20px] xl:hidden">
+          <Sheet>
+            <SheetTrigger className="inline-flex min-h-[44px] items-center gap-[8px] rounded-md border border-border/25 bg-card/30 px-[12px] text-[13px] text-muted-foreground transition-colors hover:bg-accent/30 hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+              <Menu className="h-[15px] w-[15px]" />
+              打开文档目录
+            </SheetTrigger>
+            <SheetContent side="left" className="w-[min(88vw,340px)] bg-background/95 p-[20px] backdrop-blur-xl">
+              <div className="mb-[20px] flex items-center gap-[8px] text-[15px] font-medium text-foreground"><BookOpen className="h-[16px] w-[16px]" />{seriesTitle}</div>
+              <SeriesDirectory seriesSlug={params.seriesSlug} currentSlug={post.slug} posts={seriesPosts} mobile />
+            </SheetContent>
+          </Sheet>
+        </div>
+
+        <div className="grid gap-[28px] pb-[64px] xl:grid-cols-[240px_minmax(0,720px)] xl:gap-[44px]">
+          <aside className="hidden xl:block">
+            <SeriesDirectory seriesSlug={params.seriesSlug} currentSlug={post.slug} posts={seriesPosts} />
+          </aside>
+
+          <article className="min-w-0">
+            <header className="mb-[28px] rounded-md border border-border/20 bg-background/25 p-[18px] sm:p-[24px]">
+              <div className="mb-[16px] flex flex-wrap items-center gap-[8px]">
+                <span className="inline-flex items-center gap-[6px] font-mono text-[11px] text-muted-foreground/45"><BookOpen className="h-[12px] w-[12px]" />DOCS / {seriesTitle.toUpperCase()}</span>
+                {post.category && <Badge variant="outline" className="h-[22px] rounded-[4px] px-[7px] text-[11px]">{post.category}</Badge>}
+              </div>
+              <h1 className="font-heading text-[30px] font-semibold leading-[1.08] tracking-[-0.035em] text-foreground sm:text-[42px]">{post.title}</h1>
+              <p className="mt-[14px] max-w-[680px] text-[15px] leading-[1.8] text-muted-foreground">{post.excerpt}</p>
+              <div className="mt-[18px] flex flex-wrap items-center gap-[10px] border-t border-border/16 pt-[12px] text-[12px] text-muted-foreground/50">
+                <span>{formatSiteDate(post.createdAt, dateSettings)}</span>
+                <span aria-hidden="true">·</span>
+                <span>{currentIndex + 1} / {seriesPosts.length}</span>
+              </div>
+            </header>
+
+            {headings.length >= 2 && <div className="mb-[24px] xl:hidden"><TableOfContents headings={headings} /></div>}
+
+            <div className="prose-monolith" dangerouslySetInnerHTML={{ __html: htmlContent }} />
+
+            <div className="mt-[44px] grid gap-[10px] border-t border-border/20 pt-[20px] sm:grid-cols-2">
+              {previous ? (
+                <Link href={`/docs/${params.seriesSlug}/${previous.slug}`} className="group flex min-h-[72px] items-center gap-[10px] rounded-md border border-border/18 bg-card/15 p-[12px] transition-colors hover:bg-card/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+                  <ChevronLeft className="h-[16px] w-[16px] shrink-0 text-muted-foreground/55 transition-transform group-hover:-translate-x-[2px]" />
+                  <span className="min-w-0"><span className="block text-[11px] text-muted-foreground/45">上一篇</span><span className="mt-[4px] block truncate text-[13px] text-foreground/80">{previous.title}</span></span>
+                </Link>
+              ) : <div />}
+              {next && (
+                <Link href={`/docs/${params.seriesSlug}/${next.slug}`} className="group flex min-h-[72px] items-center justify-end gap-[10px] rounded-md border border-border/18 bg-card/15 p-[12px] text-right transition-colors hover:bg-card/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
+                  <span className="min-w-0"><span className="block text-[11px] text-muted-foreground/45">下一篇</span><span className="mt-[4px] block truncate text-[13px] text-foreground/80">{next.title}</span></span><ChevronRight className="h-[16px] w-[16px] shrink-0 text-muted-foreground/55 transition-transform group-hover:translate-x-[2px]" />
+                </Link>
+              )}
+            </div>
+          </article>
+
+          <div className="hidden xl:block xl:col-start-2">
+            {headings.length >= 2 && <TableOfContents headings={headings} />}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/client/src/pages/docs.tsx
+++ b/client/src/pages/docs.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "wouter";
 import { BookOpen, ChevronLeft, ChevronRight, List, Menu } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { SeoHead } from "@/components/seo-head";
 import { TableOfContents, ReadingProgressBar } from "@/components/toc";
 import { fetchPost, fetchSeriesPosts, type Post, type SeriesPost } from "@/lib/api";
@@ -148,7 +148,7 @@ export function DocsPage() {
       />
       <ReadingProgressBar />
 
-      <div className="mx-auto w-full max-w-[1180px] px-[16px] sm:px-[20px] lg:px-[32px]">
+      <div className="mx-auto w-full max-w-[1240px] px-[16px] sm:px-[20px] lg:px-[32px] xl:px-[20px]">
         <div className="flex items-center gap-[8px] py-[18px] text-[12px] text-muted-foreground/50">
           <Link href="/" className="transition-colors hover:text-foreground">首页</Link>
           <ChevronRight className="h-[12px] w-[12px]" />
@@ -164,13 +164,13 @@ export function DocsPage() {
               打开文档目录
             </SheetTrigger>
             <SheetContent side="left" className="w-[min(88vw,340px)] bg-background/95 p-[20px] backdrop-blur-xl">
-              <div className="mb-[20px] flex items-center gap-[8px] text-[15px] font-medium text-foreground"><BookOpen className="h-[16px] w-[16px]" />{seriesTitle}</div>
+              <SheetTitle className="mb-[20px] flex items-center gap-[8px] text-[15px]"><BookOpen className="h-[16px] w-[16px]" />{seriesTitle}</SheetTitle>
               <SeriesDirectory seriesSlug={params.seriesSlug} currentSlug={post.slug} posts={seriesPosts} mobile />
             </SheetContent>
           </Sheet>
         </div>
 
-        <div className="grid gap-[28px] pb-[64px] xl:grid-cols-[240px_minmax(0,720px)] xl:gap-[44px]">
+        <div className="grid gap-[28px] pb-[64px] xl:grid-cols-[200px_minmax(0,720px)_180px] xl:gap-[28px]">
           <aside className="hidden xl:block">
             <SeriesDirectory seriesSlug={params.seriesSlug} currentSlug={post.slug} posts={seriesPosts} />
           </aside>
@@ -209,7 +209,7 @@ export function DocsPage() {
             </div>
           </article>
 
-          <div className="hidden xl:block xl:col-start-2">
+          <div className="hidden xl:col-start-3 xl:block">
             {headings.length >= 2 && <TableOfContents headings={headings} />}
           </div>
         </div>

--- a/client/src/pages/docs.tsx
+++ b/client/src/pages/docs.tsx
@@ -75,8 +75,16 @@ export function DocsPage() {
         const currentPost = await fetchPost(currentSlug);
         if (!cancelled) setPost(currentPost);
       })
-      .catch(() => {
-        if (!cancelled) setError("文档系列加载失败，请检查链接或稍后重试。");
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        if (
+          cause instanceof Error
+          && (cause.message === "文档系列不存在" || cause.message === "文章不存在")
+        ) {
+          setError(cause.message);
+          return;
+        }
+        setError("文档系列加载失败，请检查链接或稍后重试。");
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/client/src/pages/docs.tsx
+++ b/client/src/pages/docs.tsx
@@ -67,10 +67,11 @@ export function DocsPage() {
       .then(async (items) => {
         if (cancelled) return;
         setSeriesPosts(items);
-        const currentSlug = params.slug && items.some((item) => item.slug === params.slug)
-          ? params.slug
-          : items[0]?.slug;
+        const currentSlug = params.slug ?? items[0]?.slug;
         if (!currentSlug) throw new Error("文档系列不存在");
+        if (params.slug && !items.some((item) => item.slug === params.slug)) {
+          throw new Error("文章不存在");
+        }
         const currentPost = await fetchPost(currentSlug);
         if (!cancelled) setPost(currentPost);
       })

--- a/client/src/pages/guestbook.tsx
+++ b/client/src/pages/guestbook.tsx
@@ -6,6 +6,8 @@ import {
   submitGuestbookMessage,
   type GuestbookMessage,
 } from "@/lib/api";
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 type FormState = {
   authorName: string;
@@ -23,21 +25,12 @@ const EMPTY_FORM: FormState = {
 
 const inputClass = "h-[42px] w-full rounded-md border border-border/25 bg-background/35 px-[12px] text-[13px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/35 focus:border-foreground/25";
 
-function formatDate(value: string) {
-  return new Date(value).toLocaleDateString("zh-CN", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
 function getInitial(name: string) {
   return name.trim().slice(0, 1).toUpperCase() || "M";
 }
 
 export function GuestbookPage() {
+  const { dateSettings } = useSiteSettings();
   const [messages, setMessages] = useState<GuestbookMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -161,7 +154,7 @@ export function GuestbookPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-baseline gap-x-[8px] gap-y-[2px]">
                         <h3 className="text-[14px] font-medium text-foreground">{message.authorName}</h3>
-                        <span className="text-[12px] text-muted-foreground/38">{formatDate(message.createdAt)}</span>
+                        <span className="text-[12px] text-muted-foreground/38">{formatSiteDate(message.createdAt, dateSettings)}</span>
                       </div>
                       <p className="mt-[8px] whitespace-pre-wrap break-words text-[13px] leading-[1.8] text-muted-foreground/72">
                         {message.content}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -9,28 +9,7 @@ import { AnimateIn } from "@/hooks/use-animate";
 import { SeoHead } from "@/components/seo-head";
 import { ExternalLink, Mail, Rss, Eye, FolderOpen, Hash, ChevronDown, Link2 } from "lucide-react";
 import { clampCardWidth, getArticleCardGridClass } from "@/lib/card-layout";
-
-type PublicSettings = {
-  site_title: string;
-  site_description: string;
-  site_tagline: string;
-  hero_kicker: string;
-  hero_subtitle: string;
-  hero_description: string;
-  hero_actions: string;
-  hero_topics: string;
-  site_icon: string;
-  site_og_image: string;
-  author_name: string;
-  author_title: string;
-  author_bio: string;
-  author_avatar: string;
-  github_url: string;
-  twitter_url: string;
-  email: string;
-  social_links: string;
-  rss_enabled: string;
-};
+import { useSiteSettings, type PublicSiteSettings } from "@/lib/site-settings";
 
 const DEFAULT_HERO_ACTIONS: HeroAction[] = [
   { label: "最新文章", href: "#latest-posts" },
@@ -113,7 +92,7 @@ function normalizeSocialHref(link: SocialLinkConfig) {
   }
 }
 
-function getPublicSocialLinks(settings: PublicSettings | null): { id: string; icon: React.ElementType; href: string; label: string }[] {
+function getPublicSocialLinks(settings: PublicSiteSettings | null): { id: string; icon: React.ElementType; href: string; label: string }[] {
   if (!settings) return [];
 
   const configuredLinks = settings.social_links.trim() ? parseSocialLinks(settings.social_links) : [];
@@ -293,9 +272,9 @@ function SparkLine({ data, width = 240, height = 48 }: { data: number[]; width?:
 }
 
 export function HomePage() {
+  const { settings } = useSiteSettings();
   const [posts, setPosts] = useState<PostMeta[]>([]);
   const [loading, setLoading] = useState(true);
-  const [settings, setSettings] = useState<PublicSettings | null>(null);
   const [traffic, setTraffic] = useState<TrafficData | null>(null);
   const [categories, setCategories] = useState<CategoryInfo[]>([]);
 
@@ -304,11 +283,6 @@ export function HomePage() {
       .then(setPosts)
       .catch(console.error)
       .finally(() => setLoading(false));
-
-    fetch("/api/settings/public")
-      .then((r) => r.json())
-      .then((data) => setSettings(data))
-      .catch(() => {});
 
     fetch("/api/stats/traffic")
       .then((r) => r.json())
@@ -328,15 +302,15 @@ export function HomePage() {
   const sortedTags = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]);
   const maxTagCount = sortedTags.length > 0 ? sortedTags[0][1] : 1;
 
-  const authorName = settings?.author_name || "Monolith";
-  const authorTitle = settings?.author_title || "独立开发者";
-  const authorBio = settings?.author_bio || "热衷于前端架构、设计系统与边缘计算。相信技术应当服务于人，而非反过来。";
-  const authorAvatar = settings?.author_avatar || "";
-  const siteTitle = settings?.site_title || "Monolith";
-  const siteDescription = settings?.site_description || "书写代码、设计与边缘计算的个人博客。";
-  const heroDescription = settings?.hero_description || settings?.site_description || undefined;
-  const heroActions = parseHeroActions(settings?.hero_actions);
-  const heroTopics = parseHeroTopics(settings?.hero_topics);
+  const authorName = settings.author_name;
+  const authorTitle = settings.author_title;
+  const authorBio = settings.author_bio;
+  const authorAvatar = settings.author_avatar;
+  const siteTitle = settings.site_title;
+  const siteDescription = settings.site_description;
+  const heroDescription = settings.hero_description || settings.site_description || undefined;
+  const heroActions = parseHeroActions(settings.hero_actions);
+  const heroTopics = parseHeroTopics(settings.hero_topics);
 
   // 社交链接（优先读取新版可扩展列表，旧字段作为兼容回退）
   const socialLinks = getPublicSocialLinks(settings);
@@ -347,13 +321,13 @@ export function HomePage() {
       <SeoHead
         siteName={siteTitle}
         description={siteDescription}
-        image={settings?.site_og_image || undefined}
+        image={settings.site_og_image || undefined}
         url="/"
       />
       <Hero
         title={siteTitle}
-        kicker={settings?.hero_kicker || undefined}
-        subtitle={settings?.hero_subtitle || settings?.site_tagline || undefined}
+        kicker={settings.hero_kicker || undefined}
+        subtitle={settings.hero_subtitle || settings.site_tagline || undefined}
         description={heroDescription}
         actions={heroActions}
         topics={heroTopics}

--- a/client/src/pages/post.tsx
+++ b/client/src/pages/post.tsx
@@ -14,10 +14,8 @@ import { RelatedPosts } from "@/components/related-posts";
 import { SeriesNav } from "@/components/series-nav";
 import { PostReactions } from "@/components/post-reactions";
 import { ShareButtons } from "@/components/share-buttons";
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("zh-CN", { year: "numeric", month: "long", day: "numeric" });
-}
+import { useSiteSettings } from "@/lib/site-settings";
+import { formatSiteDate } from "@/lib/date-format";
 
 const renderedPostCache = new Map<string, {
   htmlContent: string;
@@ -29,6 +27,7 @@ function getRenderedPostCacheKey(post: Pick<Post, "slug" | "updatedAt">) {
 }
 
 export function PostPage() {
+  const { dateSettings } = useSiteSettings();
   const params = useParams<{ slug: string }>();
   const [post, setPost] = useState<Post | null>(null);
   const [loading, setLoading] = useState(true);
@@ -224,15 +223,15 @@ export function PostPage() {
               {post.tags.map((tag) => (
                 <Badge key={tag} variant="secondary" className="h-[22px] rounded-[4px] px-[8px] text-[12px] font-normal">{tag}</Badge>
               ))}
-              <span className="text-[12px] text-muted-foreground/50">{formatDate(post.createdAt)}</span>
+              <span className="text-[12px] text-muted-foreground/50">{formatSiteDate(post.createdAt, dateSettings)}</span>
               <span className="text-[12px] text-muted-foreground/50 inline-flex items-center gap-[4px]"><Eye className="h-[12px] w-[12px]" />{(post.viewCount ?? 0).toLocaleString()}</span>
             </div>
             <h1 className="font-heading text-[30px] font-semibold tracking-[-0.035em] leading-[1.08] sm:text-[40px] lg:text-[48px]">{post.title}</h1>
             <p className="mt-[18px] max-w-[680px] text-[16px] leading-[1.85] text-muted-foreground">{post.excerpt}</p>
             <div className="mt-[20px] grid grid-cols-2 gap-[8px] border-t border-border/16 pt-[14px] text-[12px] text-muted-foreground/52 sm:grid-cols-3">
-              <span>发布：{formatDate(post.createdAt)}</span>
+              <span>发布：{formatSiteDate(post.createdAt, dateSettings)}</span>
               <span>浏览：{(post.viewCount ?? 0).toLocaleString()}</span>
-              <span className="col-span-2 sm:col-span-1">更新：{formatDate(post.updatedAt)}</span>
+              <span className="col-span-2 sm:col-span-1">更新：{formatSiteDate(post.updatedAt, dateSettings)}</span>
             </div>
           </header>
 
@@ -277,7 +276,7 @@ export function PostPage() {
               <Link href="/" className="inline-flex min-h-[44px] items-center gap-[6px] rounded-md text-[13px] text-muted-foreground/60 transition-all duration-200 hover:-translate-x-[2px] hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring">
                 <ArrowLeft className="h-[14px] w-[14px]" />返回首页
               </Link>
-              <span className="text-[12px] text-muted-foreground/40 hidden sm:inline-block">发布于 {formatDate(post.createdAt)}</span>
+              <span className="text-[12px] text-muted-foreground/40 hidden sm:inline-block">发布于 {formatSiteDate(post.createdAt, dateSettings)}</span>
             </div>
             
             {/* 分享按钮组件 */}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -203,6 +203,30 @@ function normalizeOptionalEmail(value: unknown): string {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : "";
 }
 
+const DEFAULT_SITE_TIMEZONE = "Asia/Shanghai";
+
+function normalizeSiteTimezone(value: unknown): string {
+  if (typeof value !== "string") return DEFAULT_SITE_TIMEZONE;
+  const timezone = value.trim();
+  if (!timezone) return DEFAULT_SITE_TIMEZONE;
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+    return timezone;
+  } catch {
+    return DEFAULT_SITE_TIMEZONE;
+  }
+}
+
+function normalizeSettings(settings: unknown): Record<string, string> | undefined {
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) return undefined;
+  const normalized = { ...(settings as Record<string, string>) };
+  if (Object.prototype.hasOwnProperty.call(normalized, "site_timezone")) {
+    normalized.site_timezone = normalizeSiteTimezone(normalized.site_timezone);
+  }
+  return normalized;
+}
+
 function normalizePublicUrl(value: unknown): string {
   const raw = normalizeText(value, 500);
   if (!raw) return "";
@@ -785,7 +809,7 @@ app.get("/api/settings/public", async (c) => {
     rss_enabled: all.rss_enabled || "true",
     custom_header: all.custom_header || "",
     custom_footer: all.custom_footer || "",
-    site_timezone: all.site_timezone || "Asia/Shanghai",
+    site_timezone: normalizeSiteTimezone(all.site_timezone),
     date_precision: all.date_precision === "datetime_seconds"
       ? "datetime_seconds"
       : all.date_precision === "datetime" ? "datetime" : "date",
@@ -1633,8 +1657,7 @@ app.put("/api/admin/settings", async (c) => {
   const db = c.get("db");
   const parsed = await readJson<Record<string, string>>(c);
   if (!parsed.ok) return parsed.response;
-  const body = parsed.body;
-  await db.saveSettings(body);
+  await db.saveSettings(normalizeSettings(parsed.body) || {});
   return c.json({ success: true });
 });
 
@@ -1833,7 +1856,7 @@ app.post("/api/admin/backup/restore", async (c) => {
     const imported = await db.importAll({
       posts: body.posts,
       tags: body.tags,
-      settings: includeSettings ? body.settings : undefined,
+      settings: includeSettings ? normalizeSettings(body.settings) : undefined,
       mode: body.mode || "merge",
     });
     return c.json({ success: true, imported, mode: body.mode || "merge" });
@@ -1872,7 +1895,7 @@ app.post("/api/admin/backup/r2-restore", async (c) => {
     const imported = await db.importAll({
       posts: data.posts as Parameters<typeof db.importAll>[0]["posts"],
       tags: data.tags as Parameters<typeof db.importAll>[0]["tags"],
-      settings: (includeSettings ?? true) ? data.settings : undefined,
+      settings: (includeSettings ?? true) ? normalizeSettings(data.settings) : undefined,
       mode: mode || "merge",
     });
     return c.json({ success: true, imported, source: name, mode: mode || "merge" });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -786,7 +786,9 @@ app.get("/api/settings/public", async (c) => {
     custom_header: all.custom_header || "",
     custom_footer: all.custom_footer || "",
     site_timezone: all.site_timezone || "Asia/Shanghai",
-    date_precision: all.date_precision === "datetime" ? "datetime" : "date",
+    date_precision: all.date_precision === "datetime_seconds"
+      ? "datetime_seconds"
+      : all.date_precision === "datetime" ? "datetime" : "date",
   });
 });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -785,6 +785,8 @@ app.get("/api/settings/public", async (c) => {
     rss_enabled: all.rss_enabled || "true",
     custom_header: all.custom_header || "",
     custom_footer: all.custom_footer || "",
+    site_timezone: all.site_timezone || "Asia/Shanghai",
+    date_precision: all.date_precision === "datetime" ? "datetime" : "date",
   });
 });
 


### PR DESCRIPTION
## Summary

- add site-level IANA timezone and date precision settings, including SQLite UTC normalization
- delay the public shell until settings are ready to avoid default-template flash
- add a docs-series viewer with directory, breadcrumbs, previous/next navigation, mobile drawer, TOC, SEO metadata, and a blog-page entry point

## Issue handling

- Fixes #111
- Refs #108 (MVP delivered; series mode, nested chapters, search priority, and docs-specific sitemap remain follow-up work)

## Validation

- client ESLint: passed
- server ESLint: passed
- server TypeScript check: passed
- Vite production bundle: passed in the existing workspace dependency set
- git diff --check: passed

The full client typecheck in this desktop environment is currently blocked by a pre-existing duplicate Monaco type resolution (0.55.1 at the workspace root versus 0.56.0 in the client dependency tree); the changed files themselves pass ESLint and the production bundle resolves successfully.