### PR TITLE
refactor(client): tokenize component colors into theme variables

### DIFF
--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -86,6 +86,166 @@
   --sidebar-accent-foreground: oklch(0.90 0 220);
   --sidebar-border: oklch(1 0 220 / 10%);
   --sidebar-ring: oklch(0.55 0 220);
+
+  /* ── 文章排版（prose-monolith）── */
+  --prose-body: oklch(0.85 0 0);
+  --prose-h2: oklch(0.95 0 0);
+  --prose-h3: oklch(0.92 0 0);
+  --prose-h4: oklch(0.90 0 0);
+  --prose-strong: oklch(0.95 0 0);
+  --prose-link: oklch(0.7 0.12 220);
+  --prose-link-hover: oklch(0.8 0.15 220);
+  --prose-link-underline: oklch(0.7 0.12 220 / 30%);
+  --prose-link-underline-hover: oklch(0.8 0.15 220 / 60%);
+  --prose-marker: oklch(0.55 0 0);
+  --prose-quote-border: oklch(0.5 0.1 220 / 50%);
+  --prose-quote-bg: oklch(1 0 0 / 4%);
+  --prose-quote-text: oklch(0.78 0 0);
+  --prose-code-bg: oklch(1 0 0 / 6%);
+  --prose-code-border: oklch(1 0 0 / 8%);
+  --prose-code-text: oklch(0.85 0.06 220);
+  --prose-hr: oklch(1 0 0 / 8%);
+  --prose-table-border: oklch(1 0 0 / 6%);
+  --prose-th-bg: oklch(1 0 0 / 3%);
+  --prose-th-text: oklch(0.88 0 0);
+  --prose-th-border: oklch(1 0 0 / 10%);
+  --prose-td-text: oklch(0.75 0 0);
+  --prose-td-border: oklch(1 0 0 / 6%);
+  --prose-tr-hover-bg: oklch(1 0 0 / 2%);
+  --prose-figure-border: oklch(1 0 0 / 6%);
+  --prose-figcaption: oklch(0.55 0 0);
+
+  /* ── 代码块（code-block-wrapper / pre / header）── */
+  --code-bg: oklch(0.15 0.006 220);
+  --code-border: oklch(1 0 0 / 6%);
+  --code-text: oklch(0.85 0 0);
+  --code-header-bg: oklch(0.13 0.006 220);
+  --code-header-border: oklch(1 0 0 / 6%);
+  --code-lang-text: oklch(0.5 0.02 220);
+  --code-title-bg: oklch(0.18 0.006 220);
+  --code-title-border: oklch(1 0 0 / 6%);
+  --code-title-text: oklch(0.55 0 0);
+  --code-line-text: oklch(0.35 0 0);
+  --code-copy-bg: oklch(1 0 0 / 4%);
+  --code-copy-border: oklch(1 0 0 / 8%);
+  --code-copy-text: oklch(0.45 0 0);
+  --code-copy-hover-bg: oklch(1 0 0 / 8%);
+  --code-copy-hover-border: oklch(1 0 0 / 15%);
+  --code-copy-hover-text: oklch(0.7 0 0);
+  --code-highlight-bg: oklch(0.65 0.15 200 / 10%);
+  --code-highlight-border: oklch(0.65 0.15 200);
+  --code-diff-add-bg: oklch(0.55 0.15 145 / 12%);
+  --code-diff-add-border: oklch(0.6 0.17 145);
+  --code-diff-del-bg: oklch(0.55 0.15 25 / 12%);
+  --code-diff-del-border: oklch(0.6 0.17 25);
+  --code-line-num-text: inherit;
+  --code-line-num-border: transparent;
+  --code-mobile-radius: 8px;
+
+  /* ── 代码高亮（hljs）── */
+  --hljs-base: oklch(0.88 0 0);
+  --hljs-keyword: oklch(0.78 0.16 200);
+  --hljs-string: oklch(0.78 0.12 150);
+  --hljs-number: oklch(0.82 0.13 60);
+  --hljs-comment: oklch(0.65 0 0);
+  --hljs-function: oklch(0.85 0.1 230);
+  --hljs-title: oklch(0.85 0.12 230);
+  --hljs-params: oklch(0.85 0.06 60);
+  --hljs-type: oklch(0.82 0.12 200);
+  --hljs-literal: oklch(0.78 0.13 30);
+  --hljs-attr: oklch(0.85 0.1 80);
+  --hljs-property: oklch(0.85 0.08 230);
+  --hljs-meta: oklch(0.75 0.08 220);
+  --hljs-punctuation: oklch(0.70 0 0);
+  --hljs-variable: oklch(0.88 0.06 200);
+  --hljs-tag: oklch(0.78 0.14 10);
+  --hljs-selector: oklch(0.82 0.12 80);
+
+  /* ── 目录（TOC）── */
+  --toc-text: oklch(0.55 0 0);
+  --toc-hover-text: oklch(0.82 0 0);
+  --toc-hover-bg: oklch(1 0 0 / 4%);
+  --toc-hover-border: oklch(1 0 0 / 12%);
+  --toc-active-text: oklch(0.88 0 220);
+  --toc-active-bg: color-mix(in oklch, var(--foreground) 6%, transparent);
+  --toc-active-border: color-mix(in oklch, var(--foreground) 58%, transparent);
+
+  /* ── 系列导航（series-nav）── */
+  --series-border: oklch(0.35 0 0 / 40%);
+  --series-bg: oklch(0.18 0 0 / 50%);
+  --series-header-border: oklch(0.35 0 0 / 30%);
+  --series-toggle-text: oklch(0.7 0 0);
+  --series-toggle-hover: oklch(0.9 0 0);
+  --series-title: oklch(0.85 0.08 220);
+  --series-docs-text: oklch(0.7 0 0);
+  --series-docs-border: oklch(0.55 0 0 / 24%);
+  --series-docs-hover-text: oklch(0.9 0 0);
+  --series-docs-hover-border: oklch(0.75 0 0 / 42%);
+  --series-docs-hover-bg: oklch(0.3 0 0 / 20%);
+  --series-docs-focus: oklch(0.75 0 0 / 70%);
+  --series-list-border: oklch(0.35 0 0 / 30%);
+  --series-link-text: oklch(0.65 0 0);
+  --series-link-hover-text: oklch(0.9 0 0);
+  --series-link-hover-bg: oklch(0.3 0 0 / 20%);
+  --series-current-text: oklch(0.85 0.1 220);
+  --series-current-bg: oklch(0.65 0.18 220 / 8%);
+  --series-current-border: oklch(0.65 0.18 220);
+  --series-arrow-text: oklch(0.7 0 0);
+  --series-arrow-hover-text: oklch(0.9 0 0);
+  --series-arrow-hover-bg: oklch(0.3 0 0 / 20%);
+
+  /* ── 文章表情（post-reactions）── */
+  --reaction-label: oklch(0.5 0 0);
+  --reaction-btn-border: oklch(0.35 0 0 / 40%);
+  --reaction-btn-bg: oklch(0.18 0 0 / 50%);
+  --reaction-btn-text: oklch(0.6 0 0);
+  --reaction-btn-hover-border: oklch(0.45 0 0);
+  --reaction-btn-hover-bg: oklch(0.25 0 0 / 60%);
+  --reaction-active-border: oklch(0.55 0.18 220 / 60%);
+  --reaction-active-bg: oklch(0.55 0.18 220 / 12%);
+  --reaction-active-text: oklch(0.85 0.1 220);
+  --reaction-active-hover-border: oklch(0.55 0.18 220 / 80%);
+  --reaction-active-hover-bg: oklch(0.55 0.18 220 / 18%);
+
+  /* ── 访客分析面板（analytics）── */
+  --analytics-card-bg: oklch(0.17 0 0 / 72%);
+  --analytics-card-border: oklch(0.42 0 0 / 46%);
+  --analytics-value: oklch(0.9 0 0);
+  --analytics-section-title: oklch(0.7 0 0);
+  --analytics-section-title-border: oklch(0.42 0 0 / 36%);
+  --analytics-bar-bg: linear-gradient(to top, oklch(0.5 0 0), oklch(0.74 0 0));
+  --analytics-bar-track-bg: oklch(0.25 0 0 / 50%);
+  --analytics-list-name: oklch(0.7 0 0);
+  --analytics-list-count: oklch(0.65 0 0);
+  --analytics-explain: oklch(0.64 0 0);
+  --analytics-insight-desc: oklch(0.63 0 0);
+  --analytics-list-meaning: oklch(0.52 0 0);
+  --analytics-empty-detail: oklch(0.55 0 0);
+  --analytics-surface-bg: oklch(0.14 0 0 / 48%);
+  --analytics-surface-border: oklch(0.38 0 0 / 42%);
+  --analytics-insight-title: oklch(0.84 0 0);
+  --analytics-empty-title: oklch(0.78 0 0);
+  --analytics-insight-action: oklch(0.76 0 0);
+  --analytics-skeleton-border: oklch(0.42 0 0 / 32%);
+  --analytics-skeleton-bg: linear-gradient(90deg, oklch(0.2 0 0 / 60%), oklch(0.28 0 0 / 60%), oklch(0.2 0 0 / 60%));
+  --analytics-filter-hover-bg: oklch(0.24 0 0 / 62%);
+  --analytics-filter-hover-border: oklch(0.78 0 0 / 62%);
+  --analytics-strong-text: oklch(0.82 0 0);
+  --analytics-search-name: oklch(0.78 0 0);
+  --analytics-big-value: oklch(0.9 0 0);
+  --analytics-filter-detail: oklch(0.58 0 0);
+  --analytics-lifecycle-meta: oklch(0.56 0 0);
+  --analytics-lifecycle-desc: oklch(0.66 0 0);
+  --analytics-empty-bg: oklch(0.2 0 0 / 42%);
+  --analytics-empty-text: oklch(0.52 0 0);
+  --analytics-action-bg: oklch(0.22 0 0 / 52%);
+  --analytics-action-text: oklch(0.7 0 0);
+  --analytics-textarea-bg: oklch(0.12 0 0 / 78%);
+  --analytics-textarea-border: oklch(0.38 0 0 / 42%);
+  --analytics-textarea-text: oklch(0.76 0 0);
+  --analytics-concentration-label: oklch(0.58 0 0);
+  --analytics-concentration-explain: oklch(0.68 0 0);
+
   color-scheme: dark;
 }
 
@@ -123,6 +283,166 @@
   --sidebar-accent-foreground: oklch(0.16 0 250);
   --sidebar-border: oklch(0 0 0 / 9%);
   --sidebar-ring: oklch(0.55 0.02 250);
+
+  /* ── 文章排版（prose-monolith）── */
+  --prose-body: oklch(0.25 0 0);
+  --prose-h2: oklch(0.12 0 0);
+  --prose-h3: oklch(0.15 0 0);
+  --prose-h4: oklch(0.18 0 0);
+  --prose-strong: oklch(0.12 0 0);
+  --prose-link: oklch(0.42 0.16 250);
+  --prose-link-hover: oklch(0.35 0.20 250);
+  --prose-link-underline: oklch(0.42 0.16 250 / 40%);
+  --prose-link-underline-hover: oklch(0.35 0.20 250 / 70%);
+  --prose-marker: oklch(0.45 0 0);
+  --prose-quote-border: oklch(0.5 0.12 250 / 60%);
+  --prose-quote-bg: oklch(0 0 0 / 3%);
+  --prose-quote-text: oklch(0.35 0 0);
+  --prose-code-bg: oklch(0 0 0 / 5%);
+  --prose-code-border: oklch(0 0 0 / 8%);
+  --prose-code-text: oklch(0.35 0.10 250);
+  --prose-hr: oklch(0 0 0 / 10%);
+  --prose-table-border: oklch(0 0 0 / 8%);
+  --prose-th-bg: oklch(0 0 0 / 3%);
+  --prose-th-text: oklch(0.20 0 0);
+  --prose-th-border: oklch(0 0 0 / 12%);
+  --prose-td-text: oklch(0.30 0 0);
+  --prose-td-border: oklch(0 0 0 / 6%);
+  --prose-tr-hover-bg: oklch(0 0 0 / 2%);
+  --prose-figure-border: oklch(0 0 0 / 8%);
+  --prose-figcaption: oklch(0.45 0 0);
+
+  /* ── 代码块（code-block-wrapper / pre / header）── */
+  --code-bg: oklch(0.96 0.002 250);
+  --code-border: oklch(0 0 0 / 8%);
+  --code-text: oklch(0.30 0 0);
+  --code-header-bg: oklch(0.93 0.002 250);
+  --code-header-border: oklch(0 0 0 / 8%);
+  --code-lang-text: oklch(0.45 0.02 250);
+  --code-title-bg: oklch(0.93 0.002 250);
+  --code-title-border: oklch(0 0 0 / 8%);
+  --code-title-text: oklch(0.45 0 0);
+  --code-line-text: oklch(0.65 0 0);
+  --code-copy-bg: oklch(0.93 0 0);
+  --code-copy-border: oklch(0 0 0 / 10%);
+  --code-copy-text: oklch(0.45 0 0);
+  --code-copy-hover-bg: oklch(0.90 0 0);
+  --code-copy-hover-border: oklch(0 0 0 / 15%);
+  --code-copy-hover-text: oklch(0.25 0 0);
+  --code-highlight-bg: oklch(0.55 0.12 220 / 8%);
+  --code-highlight-border: oklch(0.55 0.12 220);
+  --code-diff-add-bg: oklch(0.55 0.15 145 / 8%);
+  --code-diff-add-border: oklch(0.5 0.17 145);
+  --code-diff-del-bg: oklch(0.55 0.15 25 / 8%);
+  --code-diff-del-border: oklch(0.5 0.17 25);
+  --code-line-num-text: oklch(0.65 0 0);
+  --code-line-num-border: oklch(0 0 0 / 6%);
+  --code-mobile-radius: 0;
+
+  /* ── 代码高亮（hljs）── */
+  --hljs-base: oklch(0.30 0 0);
+  --hljs-keyword: oklch(0.42 0.20 290);
+  --hljs-string: oklch(0.45 0.16 150);
+  --hljs-number: oklch(0.48 0.16 60);
+  --hljs-comment: oklch(0.55 0 0);
+  --hljs-function: oklch(0.42 0.16 230);
+  --hljs-title: oklch(0.42 0.16 230);
+  --hljs-params: oklch(0.45 0.08 60);
+  --hljs-type: oklch(0.42 0.16 200);
+  --hljs-literal: oklch(0.42 0.16 30);
+  --hljs-attr: oklch(0.48 0.14 80);
+  --hljs-property: oklch(0.42 0.12 230);
+  --hljs-meta: oklch(0.45 0.10 220);
+  --hljs-punctuation: oklch(0.40 0 0);
+  --hljs-variable: oklch(0.40 0.08 200);
+  --hljs-tag: oklch(0.45 0.18 10);
+  --hljs-selector: oklch(0.48 0.16 80);
+
+  /* ── 目录（TOC）── */
+  --toc-text: oklch(0.42 0 0);
+  --toc-hover-text: oklch(0.18 0 0);
+  --toc-hover-bg: oklch(0 0 0 / 4%);
+  --toc-hover-border: oklch(0 0 0 / 14%);
+  --toc-active-text: oklch(0.20 0.006 250);
+  --toc-active-bg: oklch(0 0 0 / 5%);
+  --toc-active-border: oklch(0 0 0 / 32%);
+
+  /* ── 系列导航（series-nav）── */
+  --series-border: oklch(0.85 0 0 / 50%);
+  --series-bg: oklch(0.97 0 0);
+  --series-header-border: oklch(0.88 0 0 / 40%);
+  --series-toggle-text: oklch(0.4 0 0);
+  --series-toggle-hover: oklch(0.15 0 0);
+  --series-title: oklch(0.45 0.12 220);
+  --series-docs-text: oklch(0.4 0 0);
+  --series-docs-border: oklch(0.55 0 0 / 28%);
+  --series-docs-hover-text: oklch(0.15 0 0);
+  --series-docs-hover-border: oklch(0.35 0 0 / 42%);
+  --series-docs-hover-bg: oklch(0.92 0 0 / 50%);
+  --series-docs-focus: oklch(0.35 0 0);
+  --series-list-border: oklch(0.88 0 0 / 40%);
+  --series-link-text: oklch(0.4 0 0);
+  --series-link-hover-text: oklch(0.15 0 0);
+  --series-link-hover-bg: oklch(0.92 0 0 / 50%);
+  --series-current-text: oklch(0.4 0.15 220);
+  --series-current-bg: oklch(0.55 0.18 220 / 8%);
+  --series-current-border: oklch(0.55 0.18 220);
+  --series-arrow-text: oklch(0.4 0 0);
+  --series-arrow-hover-text: oklch(0.15 0 0);
+  --series-arrow-hover-bg: oklch(0.92 0 0 / 50%);
+
+  /* ── 文章表情（post-reactions）── */
+  --reaction-label: oklch(0.5 0 0);
+  --reaction-btn-border: oklch(0.85 0 0 / 50%);
+  --reaction-btn-bg: oklch(0.97 0 0);
+  --reaction-btn-text: oklch(0.4 0 0);
+  --reaction-btn-hover-border: oklch(0.7 0 0);
+  --reaction-btn-hover-bg: oklch(0.94 0 0);
+  --reaction-active-border: oklch(0.55 0.18 220 / 50%);
+  --reaction-active-bg: oklch(0.55 0.18 220 / 8%);
+  --reaction-active-text: oklch(0.4 0.15 220);
+  --reaction-active-hover-border: oklch(0.55 0.18 220 / 70%);
+  --reaction-active-hover-bg: oklch(0.55 0.18 220 / 14%);
+
+  /* ── 访客分析面板（analytics）── */
+  --analytics-card-bg: oklch(0.985 0 0);
+  --analytics-card-border: oklch(0.72 0 0 / 58%);
+  --analytics-value: oklch(0.15 0 0);
+  --analytics-section-title: oklch(0.35 0 0);
+  --analytics-section-title-border: oklch(0.78 0 0 / 46%);
+  --analytics-bar-bg: linear-gradient(to top, oklch(0.42 0 0), oklch(0.68 0 0));
+  --analytics-bar-track-bg: oklch(0.92 0 0);
+  --analytics-list-name: oklch(0.35 0 0);
+  --analytics-list-count: oklch(0.35 0 0);
+  --analytics-explain: oklch(0.42 0 0);
+  --analytics-insight-desc: oklch(0.42 0 0);
+  --analytics-list-meaning: oklch(0.42 0 0);
+  --analytics-empty-detail: oklch(0.42 0 0);
+  --analytics-surface-bg: oklch(0.96 0 0);
+  --analytics-surface-border: oklch(0.74 0 0 / 50%);
+  --analytics-insight-title: oklch(0.22 0 0);
+  --analytics-empty-title: oklch(0.22 0 0);
+  --analytics-insight-action: oklch(0.3 0 0);
+  --analytics-skeleton-border: oklch(0.74 0 0 / 45%);
+  --analytics-skeleton-bg: linear-gradient(90deg, oklch(0.94 0 0), oklch(0.88 0 0), oklch(0.94 0 0));
+  --analytics-filter-hover-bg: oklch(0.92 0 0);
+  --analytics-filter-hover-border: oklch(0.36 0 0 / 50%);
+  --analytics-strong-text: oklch(0.22 0 0);
+  --analytics-search-name: oklch(0.22 0 0);
+  --analytics-big-value: oklch(0.16 0 0);
+  --analytics-filter-detail: oklch(0.42 0 0);
+  --analytics-lifecycle-meta: oklch(0.42 0 0);
+  --analytics-lifecycle-desc: oklch(0.42 0 0);
+  --analytics-empty-bg: oklch(0.9 0 0);
+  --analytics-empty-text: oklch(0.36 0 0);
+  --analytics-action-bg: oklch(0.9 0 0);
+  --analytics-action-text: oklch(0.36 0 0);
+  --analytics-textarea-bg: oklch(0.94 0 0);
+  --analytics-textarea-border: oklch(0.74 0 0 / 50%);
+  --analytics-textarea-text: oklch(0.26 0 0);
+  --analytics-concentration-label: oklch(0.38 0 0);
+  --analytics-concentration-explain: oklch(0.38 0 0);
+
   color-scheme: light;
 }
 
@@ -316,7 +636,7 @@
   font-size: 16px;
   line-height: 1.9;
   letter-spacing: 0;
-  color: oklch(0.85 0 0);
+  color: var(--prose-body);
   word-spacing: 0;
   overflow-wrap: anywhere;
 }
@@ -329,7 +649,7 @@
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1.4;
-  color: oklch(0.95 0 0);
+  color: var(--prose-h2);
 }
 
 .prose-monolith h3 {
@@ -339,7 +659,7 @@
   font-weight: 600;
   letter-spacing: 0;
   line-height: 1.5;
-  color: oklch(0.92 0 0);
+  color: var(--prose-h3);
 }
 
 .prose-monolith h4 {
@@ -348,7 +668,7 @@
   font-size: 16px;
   font-weight: 600;
   line-height: 1.5;
-  color: oklch(0.90 0 0);
+  color: var(--prose-h4);
 }
 
 /* 段落 */
@@ -358,22 +678,22 @@
 
 /* 链接 */
 .prose-monolith a {
-  color: oklch(0.7 0.12 220);
+  color: var(--prose-link);
   text-decoration: underline;
-  text-decoration-color: oklch(0.7 0.12 220 / 30%);
+  text-decoration-color: var(--prose-link-underline);
   text-underline-offset: 3px;
   transition: all 0.2s ease;
 }
 
 .prose-monolith a:hover {
-  color: oklch(0.8 0.15 220);
-  text-decoration-color: oklch(0.8 0.15 220 / 60%);
+  color: var(--prose-link-hover);
+  text-decoration-color: var(--prose-link-underline-hover);
 }
 
 /* 粗体 */
 .prose-monolith strong {
   font-weight: 600;
-  color: oklch(0.95 0 0);
+  color: var(--prose-strong);
 }
 
 /* 列表 */
@@ -398,22 +718,22 @@
 }
 
 .prose-monolith li::marker {
-  color: oklch(0.55 0 0);
+  color: var(--prose-marker);
 }
 
 /* 引用块 */
 .prose-monolith blockquote {
   margin: 28px 0;
   padding: 16px 24px;
-  border-left: 3px solid oklch(0.5 0.1 220 / 50%);
-  background: oklch(1 0 0 / 4%);
+  border-left: 3px solid var(--prose-quote-border);
+  background: var(--prose-quote-bg);
   border-radius: 0 8px 8px 0;
   font-style: normal;
 }
 
 .prose-monolith blockquote p {
   margin-bottom: 0;
-  color: oklch(0.78 0 0);
+  color: var(--prose-quote-text);
 }
 
 /* 行内代码 */
@@ -422,10 +742,10 @@
   margin: 0 3px;
   font-size: 13px;
   font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
-  background: oklch(1 0 0 / 6%);
-  border: 1px solid oklch(1 0 0 / 8%);
+  background: var(--prose-code-bg);
+  border: 1px solid var(--prose-code-border);
   border-radius: 5px;
-  color: oklch(0.85 0.06 220);
+  color: var(--prose-code-text);
   overflow-wrap: anywhere;
 }
 
@@ -451,8 +771,8 @@
 .prose-monolith .code-block-wrapper {
   margin: 24px 0;
   border-radius: 8px;
-  background: oklch(0.15 0.006 220) !important;
-  border: 1px solid oklch(1 0 0 / 6%);
+  background: var(--code-bg) !important;
+  border: 1px solid var(--code-border);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch; /* iOS 惯性滚动 */
 }
@@ -473,6 +793,10 @@
 }
 
 @media (max-width: 768px) {
+  .prose-monolith .code-block-wrapper {
+    border-radius: var(--code-mobile-radius);
+  }
+
   .prose-monolith .code-block-wrapper pre {
     padding: 10px 12px;
   }
@@ -520,8 +844,8 @@
   margin: 24px 0;
   padding: 14px 24px;
   border-radius: 8px;
-  background: oklch(0.15 0.006 220) !important;
-  border: 1px solid oklch(1 0 0 / 6%);
+  background: var(--code-bg) !important;
+  border: 1px solid var(--code-border);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch; /* iOS 惯性滚动 */
   white-space: pre; /* 强制不换行 */
@@ -536,7 +860,7 @@
   background: transparent !important;
   border: none;
   font-size: inherit;
-  color: oklch(0.85 0 0);
+  color: var(--code-text);
   display: block;
   min-width: 100%;
 }
@@ -575,7 +899,7 @@
 .prose-monolith hr {
   margin: 32px 0;
   border: none;
-  border-top: 1px solid oklch(1 0 0 / 8%);
+  border-top: 1px solid var(--prose-hr);
 }
 
 /* 表格响应式包裹 */
@@ -583,7 +907,7 @@
   overflow-x: auto;
   margin: 28px 0;
   border-radius: 8px;
-  border: 1px solid oklch(1 0 0 / 6%);
+  border: 1px solid var(--prose-table-border);
 }
 
 .prose-monolith table {
@@ -597,15 +921,15 @@
   padding: 10px 16px;
   text-align: left;
   font-weight: 600;
-  color: oklch(0.88 0 0);
-  background: oklch(1 0 0 / 3%);
-  border-bottom: 2px solid oklch(1 0 0 / 10%);
+  color: var(--prose-th-text);
+  background: var(--prose-th-bg);
+  border-bottom: 2px solid var(--prose-th-border);
 }
 
 .prose-monolith td {
   padding: 10px 16px;
-  border-bottom: 1px solid oklch(1 0 0 / 6%);
-  color: oklch(0.75 0 0);
+  border-bottom: 1px solid var(--prose-td-border);
+  color: var(--prose-td-text);
 }
 
 .prose-monolith tr:last-child td {
@@ -613,7 +937,7 @@
 }
 
 .prose-monolith tr:hover td {
-  background: oklch(1 0 0 / 2%);
+  background: var(--prose-tr-hover-bg);
 }
 
 /* 代码块顶部信息栏（语言标签 + 复制按钮） */
@@ -622,8 +946,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 6px 12px 6px 16px;
-  background: oklch(0.13 0.006 220);
-  border: 1px solid oklch(1 0 0 / 6%);
+  background: var(--code-header-bg);
+  border: 1px solid var(--code-header-border);
   border-bottom: none;
   border-radius: 8px 8px 0 0;
   overflow: hidden;
@@ -643,7 +967,7 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 500;
-  color: oklch(0.5 0.02 220);
+  color: var(--code-lang-text);
   pointer-events: none;
   user-select: none;
   font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
@@ -662,9 +986,9 @@
   padding: 4px 10px;
   gap: 5px;
   border-radius: 6px;
-  border: 1px solid oklch(1 0 0 / 8%);
-  background: oklch(1 0 0 / 4%);
-  color: oklch(0.45 0 0);
+  border: 1px solid var(--code-copy-border);
+  background: var(--code-copy-bg);
+  color: var(--code-copy-text);
   font-size: 11px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -673,9 +997,9 @@
 
 .prose-monolith .copy-code-btn:hover {
   opacity: 1;
-  color: oklch(0.7 0 0);
-  background: oklch(1 0 0 / 8%);
-  border-color: oklch(1 0 0 / 15%);
+  color: var(--code-copy-hover-text);
+  background: var(--code-copy-hover-bg);
+  border-color: var(--code-copy-hover-border);
 }
 
 .prose-monolith .copy-code-btn svg {
@@ -697,11 +1021,11 @@
   align-items: center;
   gap: 10px;
   padding: 10px 16px;
-  background: oklch(0.18 0.006 220);
-  border-bottom: 1px solid oklch(1 0 0 / 6%);
+  background: var(--code-title-bg);
+  border-bottom: 1px solid var(--code-title-border);
   border-radius: 8px 8px 0 0;
   font-size: 12px;
-  color: oklch(0.55 0 0);
+  color: var(--code-title-text);
   font-family: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
   overflow: hidden;
   position: sticky;
@@ -731,7 +1055,7 @@
 .prose-monolith .code-title-dots span:nth-child(3) { background: oklch(0.65 0.17 145); }
 
 .prose-monolith .code-title-text {
-  color: oklch(0.55 0 0);
+  color: var(--code-title-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -760,18 +1084,14 @@
   width: 28px;
   padding-right: 12px;
   text-align: right;
-  color: oklch(0.35 0 0);
+  color: var(--code-line-text);
   user-select: none;
   pointer-events: none;
   font-size: 11px;
   position: sticky;
   left: 0;
   z-index: 10;
-  background: oklch(0.15 0.006 220);
-}
-
-:root[data-theme="light"] .prose-monolith pre code .line-number {
-  background: oklch(0.96 0.002 250);
+  background: var(--code-bg);
 }
 
 /* 有行号时调整 pre 左边距 */
@@ -781,8 +1101,8 @@
 
 /* 高亮行 */
 .prose-monolith pre code .line-highlight {
-  background: oklch(0.65 0.15 200 / 10%);
-  border-left: 2px solid oklch(0.65 0.15 200);
+  background: var(--code-highlight-bg);
+  border-left: 2px solid var(--code-highlight-border);
   padding-left: 6px;
   margin-left: -4px;
 }
@@ -794,17 +1114,22 @@
 
 /* Diff 行高亮 */
 .prose-monolith pre code .diff-add {
-  background: oklch(0.55 0.15 145 / 12%);
-  border-left: 2px solid oklch(0.6 0.17 145);
+  background: var(--code-diff-add-bg);
+  border-left: 2px solid var(--code-diff-add-border);
   padding-left: 6px;
   margin-left: -6px;
 }
 
 .prose-monolith pre code .diff-del {
-  background: oklch(0.55 0.15 25 / 12%);
-  border-left: 2px solid oklch(0.6 0.17 25);
+  background: var(--code-diff-del-bg);
+  border-left: 2px solid var(--code-diff-del-border);
   padding-left: 6px;
   margin-left: -6px;
+}
+
+.prose-monolith .code-line-num {
+  color: var(--code-line-num-text);
+  border-color: var(--code-line-num-border);
 }
 
 /* 图片 figure */
@@ -817,13 +1142,13 @@
   max-width: 100%;
   height: auto;
   border-radius: 8px;
-  border: 1px solid oklch(1 0 0 / 6%);
+  border: 1px solid var(--prose-figure-border);
 }
 
 .prose-monolith .md-figure figcaption {
   margin-top: 8px;
   font-size: 12px;
-  color: oklch(0.55 0 0);
+  color: var(--prose-figcaption);
   font-style: italic;
 }
 
@@ -886,183 +1211,27 @@
 /* ─────────────────────────────────────────────
    Highlight.js 暗色代码高亮主题（极简定制）
    ───────────────────────────────────────────── */
-.hljs { color: oklch(0.88 0 0); }
-.hljs-keyword { color: oklch(0.78 0.16 200); }
-.hljs-string { color: oklch(0.78 0.12 150); }
-.hljs-number { color: oklch(0.82 0.13 60); }
-.hljs-comment { color: oklch(0.65 0 0); font-style: italic; }
-.hljs-function { color: oklch(0.85 0.1 230); }
-.hljs-title { color: oklch(0.85 0.12 230); }
-.hljs-title.function_ { color: oklch(0.85 0.12 230); }
-.hljs-params { color: oklch(0.85 0.06 60); }
-.hljs-type { color: oklch(0.82 0.12 200); }
-.hljs-built_in { color: oklch(0.82 0.12 200); }
-.hljs-literal { color: oklch(0.78 0.13 30); }
-.hljs-attr { color: oklch(0.85 0.1 80); }
-.hljs-property { color: oklch(0.85 0.08 230); }
-.hljs-meta { color: oklch(0.75 0.08 220); }
-.hljs-punctuation { color: oklch(0.70 0 0); }
-.hljs-variable { color: oklch(0.88 0.06 200); }
-.hljs-tag { color: oklch(0.78 0.14 10); }
-.hljs-name { color: oklch(0.78 0.14 10); }
-.hljs-selector-class { color: oklch(0.82 0.12 80); }
-.hljs-selector-id { color: oklch(0.82 0.12 80); }
-
-/* ── 亮色模式代码高亮覆盖 ─── */
-:root[data-theme="light"] .hljs { color: oklch(0.30 0 0); }
-:root[data-theme="light"] .hljs-keyword { color: oklch(0.42 0.20 290); }
-:root[data-theme="light"] .hljs-string { color: oklch(0.45 0.16 150); }
-:root[data-theme="light"] .hljs-number { color: oklch(0.48 0.16 60); }
-:root[data-theme="light"] .hljs-comment { color: oklch(0.55 0 0); }
-:root[data-theme="light"] .hljs-function,
-:root[data-theme="light"] .hljs-title,
-:root[data-theme="light"] .hljs-title.function_ { color: oklch(0.42 0.16 230); }
-:root[data-theme="light"] .hljs-params { color: oklch(0.45 0.08 60); }
-:root[data-theme="light"] .hljs-type,
-:root[data-theme="light"] .hljs-built_in { color: oklch(0.42 0.16 200); }
-:root[data-theme="light"] .hljs-literal { color: oklch(0.42 0.16 30); }
-:root[data-theme="light"] .hljs-attr { color: oklch(0.48 0.14 80); }
-:root[data-theme="light"] .hljs-property { color: oklch(0.42 0.12 230); }
-:root[data-theme="light"] .hljs-meta { color: oklch(0.45 0.10 220); }
-:root[data-theme="light"] .hljs-punctuation { color: oklch(0.40 0 0); }
-:root[data-theme="light"] .hljs-variable { color: oklch(0.40 0.08 200); }
-:root[data-theme="light"] .hljs-tag,
-:root[data-theme="light"] .hljs-name { color: oklch(0.45 0.18 10); }
-:root[data-theme="light"] .hljs-selector-class,
-:root[data-theme="light"] .hljs-selector-id { color: oklch(0.48 0.16 80); }
-
-/* ── 亮色模式代码块背景覆盖 ─── */
-:root[data-theme="light"] .prose-monolith .code-block-wrapper {
-  background: oklch(0.96 0.002 250) !important;
-  border-color: oklch(0 0 0 / 8%);
-}
-
-@media (max-width: 768px) {
-  :root[data-theme="light"] .prose-monolith .code-block-wrapper {
-    border-radius: 0;
-  }
-}
-
-:root[data-theme="light"] .prose-monolith pre {
-  background: oklch(0.96 0.002 250) !important;
-  border-color: oklch(0 0 0 / 8%);
-}
-:root[data-theme="light"] .prose-monolith pre code {
-  color: oklch(0.30 0 0);
-}
-:root[data-theme="light"] .prose-monolith code {
-  background: oklch(0.93 0.004 250);
-  color: oklch(0.35 0.08 250);
-  border-color: oklch(0 0 0 / 8%);
-}
-
-:root[data-theme="light"] .prose-monolith .copy-code-btn {
-  color: oklch(0.45 0 0);
-  background: oklch(0.93 0 0);
-  border-color: oklch(0 0 0 / 10%);
-}
-:root[data-theme="light"] .prose-monolith .copy-code-btn:hover {
-  color: oklch(0.25 0 0);
-  background: oklch(0.90 0 0);
-  border-color: oklch(0 0 0 / 15%);
-}
-:root[data-theme="light"] .prose-monolith .code-header {
-  background: oklch(0.93 0.002 250);
-  border-color: oklch(0 0 0 / 8%);
-}
-:root[data-theme="light"] .prose-monolith .code-lang {
-  color: oklch(0.45 0.02 250);
-}
-:root[data-theme="light"] .prose-monolith .code-title-bar {
-  background: oklch(0.93 0.002 250);
-  border-color: oklch(0 0 0 / 8%);
-}
-:root[data-theme="light"] .prose-monolith .code-title-text {
-  color: oklch(0.45 0 0);
-}
-:root[data-theme="light"] .prose-monolith pre code .line-number {
-  color: oklch(0.65 0 0);
-}
-:root[data-theme="light"] .prose-monolith pre code .line-highlight {
-  background: oklch(0.55 0.12 220 / 8%);
-  border-left-color: oklch(0.55 0.12 220);
-}
-:root[data-theme="light"] .prose-monolith pre code .diff-add {
-  background: oklch(0.55 0.15 145 / 8%);
-  border-left-color: oklch(0.5 0.17 145);
-}
-:root[data-theme="light"] .prose-monolith pre code .diff-del {
-  background: oklch(0.55 0.15 25 / 8%);
-  border-left-color: oklch(0.5 0.17 25);
-}
-:root[data-theme="light"] .prose-monolith .code-line-num {
-  color: oklch(0.65 0 0);
-  border-color: oklch(0 0 0 / 6%);
-}
-
-/* ── 亮色模式 prose 排版覆盖 ─── */
-:root[data-theme="light"] .prose-monolith {
-  color: oklch(0.25 0 0);
-}
-:root[data-theme="light"] .prose-monolith h2 {
-  color: oklch(0.12 0 0);
-}
-:root[data-theme="light"] .prose-monolith h3 {
-  color: oklch(0.15 0 0);
-}
-:root[data-theme="light"] .prose-monolith h4 {
-  color: oklch(0.18 0 0);
-}
-:root[data-theme="light"] .prose-monolith strong {
-  color: oklch(0.12 0 0);
-}
-:root[data-theme="light"] .prose-monolith a {
-  color: oklch(0.42 0.16 250);
-  text-decoration-color: oklch(0.42 0.16 250 / 40%);
-}
-:root[data-theme="light"] .prose-monolith a:hover {
-  color: oklch(0.35 0.20 250);
-  text-decoration-color: oklch(0.35 0.20 250 / 70%);
-}
-:root[data-theme="light"] .prose-monolith blockquote {
-  border-left-color: oklch(0.5 0.12 250 / 60%);
-  background: oklch(0 0 0 / 3%);
-}
-:root[data-theme="light"] .prose-monolith blockquote p {
-  color: oklch(0.35 0 0);
-}
-:root[data-theme="light"] .prose-monolith code:not(pre code) {
-  background: oklch(0 0 0 / 5%);
-  border-color: oklch(0 0 0 / 8%);
-  color: oklch(0.35 0.10 250);
-}
-:root[data-theme="light"] .prose-monolith li::marker {
-  color: oklch(0.45 0 0);
-}
-:root[data-theme="light"] .prose-monolith hr {
-  border-top-color: oklch(0 0 0 / 10%);
-}
-:root[data-theme="light"] .prose-monolith .table-wrapper {
-  border-color: oklch(0 0 0 / 8%);
-}
-:root[data-theme="light"] .prose-monolith th {
-  color: oklch(0.20 0 0);
-  background: oklch(0 0 0 / 3%);
-  border-bottom-color: oklch(0 0 0 / 12%);
-}
-:root[data-theme="light"] .prose-monolith td {
-  color: oklch(0.30 0 0);
-  border-bottom-color: oklch(0 0 0 / 6%);
-}
-:root[data-theme="light"] .prose-monolith tr:hover td {
-  background: oklch(0 0 0 / 2%);
-}
-:root[data-theme="light"] .prose-monolith .md-figure img {
-  border-color: oklch(0 0 0 / 8%);
-}
-:root[data-theme="light"] .prose-monolith .md-figure figcaption {
-  color: oklch(0.45 0 0);
-}
+.hljs { color: var(--hljs-base); }
+.hljs-keyword { color: var(--hljs-keyword); }
+.hljs-string { color: var(--hljs-string); }
+.hljs-number { color: var(--hljs-number); }
+.hljs-comment { color: var(--hljs-comment); font-style: italic; }
+.hljs-function { color: var(--hljs-function); }
+.hljs-title { color: var(--hljs-title); }
+.hljs-title.function_ { color: var(--hljs-title); }
+.hljs-params { color: var(--hljs-params); }
+.hljs-type { color: var(--hljs-type); }
+.hljs-built_in { color: var(--hljs-type); }
+.hljs-literal { color: var(--hljs-literal); }
+.hljs-attr { color: var(--hljs-attr); }
+.hljs-property { color: var(--hljs-property); }
+.hljs-meta { color: var(--hljs-meta); }
+.hljs-punctuation { color: var(--hljs-punctuation); }
+.hljs-variable { color: var(--hljs-variable); }
+.hljs-tag { color: var(--hljs-tag); }
+.hljs-name { color: var(--hljs-tag); }
+.hljs-selector-class { color: var(--hljs-selector); }
+.hljs-selector-id { color: var(--hljs-selector); }
 
 /* ─────────────────────────────────────────────
    滚动条样式 (Webkit)
@@ -1143,7 +1312,7 @@
   padding: 7px 12px;
   font-size: 12px;
   line-height: 1.5;
-  color: oklch(0.55 0 0);
+  color: var(--toc-text);
   border-left: 2px solid transparent;
   border-radius: 0 4px 4px 0;
   cursor: pointer;
@@ -1158,9 +1327,9 @@
 }
 
 .toc-item:hover {
-  color: oklch(0.82 0 0);
-  background: oklch(1 0 0 / 4%);
-  border-left-color: oklch(1 0 0 / 12%);
+  color: var(--toc-hover-text);
+  background: var(--toc-hover-bg);
+  border-left-color: var(--toc-hover-border);
 }
 
 .toc-item:focus-visible {
@@ -1169,9 +1338,9 @@
 }
 
 .toc-active {
-  color: oklch(0.88 0 220) !important;
-  border-left-color: color-mix(in oklch, var(--foreground) 58%, transparent) !important;
-  background: color-mix(in oklch, var(--foreground) 6%, transparent) !important;
+  color: var(--toc-active-text) !important;
+  border-left-color: var(--toc-active-border) !important;
+  background: var(--toc-active-bg) !important;
   font-weight: 500;
 }
 
@@ -1179,22 +1348,6 @@
 .toc-level-0 { padding-left: 12px; }
 .toc-level-1 { padding-left: 24px; font-size: 11.5px; }
 .toc-level-2 { padding-left: 36px; font-size: 11px; }
-
-:root[data-theme="light"] .toc-item {
-  color: oklch(0.42 0 0);
-}
-
-:root[data-theme="light"] .toc-item:hover {
-  color: oklch(0.18 0 0);
-  background: oklch(0 0 0 / 4%);
-  border-left-color: oklch(0 0 0 / 14%);
-}
-
-:root[data-theme="light"] .toc-active {
-  color: oklch(0.20 0.006 250) !important;
-  background: oklch(0 0 0 / 5%) !important;
-  border-left-color: oklch(0 0 0 / 32%) !important;
-}
 
 /* 标题锚点偏移（避免被顶部导航遮挡） */
 .prose-monolith h2[id],
@@ -1209,16 +1362,16 @@
 
 .series-nav {
   margin-top: 40px;
-  border: 1px solid oklch(0.35 0 0 / 40%);
+  border: 1px solid var(--series-border);
   border-radius: 10px;
   overflow: hidden;
-  background: oklch(0.18 0 0 / 50%);
+  background: var(--series-bg);
 }
 
 .series-nav__header {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid oklch(0.35 0 0 / 30%);
+  border-bottom: 1px solid var(--series-header-border);
 }
 
 .series-nav__toggle {
@@ -1231,13 +1384,13 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: oklch(0.7 0 0);
+  color: var(--series-toggle-text);
   font-size: 13px;
   transition: color 0.2s;
 }
 
 .series-nav__toggle:hover {
-  color: oklch(0.9 0 0);
+  color: var(--series-toggle-hover);
 }
 
 .series-nav__icon {
@@ -1248,7 +1401,7 @@
 
 .series-nav__title {
   font-weight: 600;
-  color: oklch(0.85 0.08 220);
+  color: var(--series-title);
 }
 
 .series-nav__count {
@@ -1262,22 +1415,22 @@
   flex-shrink: 0;
   margin-right: 12px;
   padding: 5px 8px;
-  border: 1px solid oklch(0.55 0 0 / 24%);
+  border: 1px solid var(--series-docs-border);
   border-radius: 5px;
-  color: oklch(0.7 0 0);
+  color: var(--series-docs-text);
   font-size: 11px;
   text-decoration: none;
   transition: color 0.2s, border-color 0.2s, background 0.2s;
 }
 
 .series-nav__docs-link:hover {
-  color: oklch(0.9 0 0);
-  border-color: oklch(0.75 0 0 / 42%);
-  background: oklch(0.3 0 0 / 20%);
+  color: var(--series-docs-hover-text);
+  border-color: var(--series-docs-hover-border);
+  background: var(--series-docs-hover-bg);
 }
 
 .series-nav__docs-link:focus-visible {
-  outline: 2px solid oklch(0.75 0 0 / 70%);
+  outline: 2px solid var(--series-docs-focus);
   outline-offset: 2px;
 }
 
@@ -1286,7 +1439,7 @@
   list-style: none;
   margin: 0;
   padding: 8px 0;
-  border-bottom: 1px solid oklch(0.35 0 0 / 30%);
+  border-bottom: 1px solid var(--series-list-border);
 }
 
 .series-nav__item {
@@ -1304,19 +1457,19 @@
 }
 
 .series-nav__link {
-  color: oklch(0.65 0 0);
+  color: var(--series-link-text);
 }
 
 .series-nav__link:hover {
-  color: oklch(0.9 0 0);
-  background: oklch(0.3 0 0 / 20%);
+  color: var(--series-link-hover-text);
+  background: var(--series-link-hover-bg);
 }
 
 .series-nav__current {
-  color: oklch(0.85 0.1 220);
+  color: var(--series-current-text);
   font-weight: 600;
-  background: oklch(0.65 0.18 220 / 8%);
-  border-left: 3px solid oklch(0.65 0.18 220);
+  background: var(--series-current-bg);
+  border-left: 3px solid var(--series-current-border);
   padding-left: 17px;
 }
 
@@ -1340,14 +1493,14 @@
   align-items: center;
   gap: 10px;
   padding: 14px 16px;
-  color: oklch(0.7 0 0);
+  color: var(--series-arrow-text);
   text-decoration: none;
   transition: all 0.2s;
 }
 
 .series-nav__arrow:hover {
-  background: oklch(0.3 0 0 / 20%);
-  color: oklch(0.9 0 0);
+  background: var(--series-arrow-hover-bg);
+  color: var(--series-arrow-hover-text);
 }
 
 .series-nav__arrow--next {
@@ -1383,71 +1536,6 @@
   text-overflow: ellipsis;
 }
 
-/* ── 亮色模式适配 ── */
-[data-theme="light"] .series-nav {
-  background: oklch(0.97 0 0);
-  border-color: oklch(0.85 0 0 / 50%);
-}
-
-[data-theme="light"] .series-nav__header {
-  border-bottom-color: oklch(0.88 0 0 / 40%);
-}
-
-[data-theme="light"] .series-nav__toggle {
-  color: oklch(0.4 0 0);
-}
-
-[data-theme="light"] .series-nav__toggle:hover {
-  color: oklch(0.15 0 0);
-}
-
-[data-theme="light"] .series-nav__docs-link {
-  color: oklch(0.4 0 0);
-  border-color: oklch(0.55 0 0 / 28%);
-}
-
-[data-theme="light"] .series-nav__docs-link:hover {
-  color: oklch(0.15 0 0);
-  border-color: oklch(0.35 0 0 / 42%);
-  background: oklch(0.92 0 0 / 50%);
-}
-
-[data-theme="light"] .series-nav__docs-link:focus-visible {
-  outline-color: oklch(0.35 0 0);
-}
-
-[data-theme="light"] .series-nav__title {
-  color: oklch(0.45 0.12 220);
-}
-
-[data-theme="light"] .series-nav__link {
-  color: oklch(0.4 0 0);
-}
-
-[data-theme="light"] .series-nav__link:hover {
-  color: oklch(0.15 0 0);
-  background: oklch(0.92 0 0 / 50%);
-}
-
-[data-theme="light"] .series-nav__current {
-  color: oklch(0.4 0.15 220);
-  background: oklch(0.55 0.18 220 / 8%);
-  border-left-color: oklch(0.55 0.18 220);
-}
-
-[data-theme="light"] .series-nav__arrow {
-  color: oklch(0.4 0 0);
-}
-
-[data-theme="light"] .series-nav__arrow:hover {
-  color: oklch(0.15 0 0);
-  background: oklch(0.92 0 0 / 50%);
-}
-
-[data-theme="light"] .series-nav__list {
-  border-bottom-color: oklch(0.88 0 0 / 40%);
-}
-
 /* ── 文章表情反应组件 ──────────────────────── */
 
 .post-reactions {
@@ -1457,7 +1545,7 @@
 
 .post-reactions__label {
   font-size: 12px;
-  color: oklch(0.5 0 0);
+  color: var(--reaction-label);
   margin-bottom: 12px;
   letter-spacing: 0.02em;
 }
@@ -1487,9 +1575,9 @@
   gap: 5px;
   padding: 8px 14px;
   border-radius: 999px;
-  border: 1px solid oklch(0.35 0 0 / 40%);
-  background: oklch(0.18 0 0 / 50%);
-  color: oklch(0.6 0 0);
+  border: 1px solid var(--reaction-btn-border);
+  background: var(--reaction-btn-bg);
+  color: var(--reaction-btn-text);
   cursor: pointer;
   font-size: 13px;
   transition: all 0.2s;
@@ -1497,20 +1585,20 @@
 }
 
 .post-reactions__btn:hover {
-  border-color: oklch(0.45 0 0);
-  background: oklch(0.25 0 0 / 60%);
+  border-color: var(--reaction-btn-hover-border);
+  background: var(--reaction-btn-hover-bg);
   transform: translateY(-1px);
 }
 
 .post-reactions__btn--active {
-  border-color: oklch(0.55 0.18 220 / 60%);
-  background: oklch(0.55 0.18 220 / 12%);
-  color: oklch(0.85 0.1 220);
+  border-color: var(--reaction-active-border);
+  background: var(--reaction-active-bg);
+  color: var(--reaction-active-text);
 }
 
 .post-reactions__btn--active:hover {
-  border-color: oklch(0.55 0.18 220 / 80%);
-  background: oklch(0.55 0.18 220 / 18%);
+  border-color: var(--reaction-active-hover-border);
+  background: var(--reaction-active-hover-bg);
 }
 
 .post-reactions__emoji {
@@ -1537,33 +1625,6 @@
   100% { transform: scale(1); }
 }
 
-/* ── 亮色模式 ── */
-[data-theme="light"] .post-reactions__label {
-  color: oklch(0.5 0 0);
-}
-
-[data-theme="light"] .post-reactions__btn {
-  border-color: oklch(0.85 0 0 / 50%);
-  background: oklch(0.97 0 0);
-  color: oklch(0.4 0 0);
-}
-
-[data-theme="light"] .post-reactions__btn:hover {
-  border-color: oklch(0.7 0 0);
-  background: oklch(0.94 0 0);
-}
-
-[data-theme="light"] .post-reactions__btn--active {
-  border-color: oklch(0.55 0.18 220 / 50%);
-  background: oklch(0.55 0.18 220 / 8%);
-  color: oklch(0.4 0.15 220);
-}
-
-[data-theme="light"] .post-reactions__btn--active:hover {
-  border-color: oklch(0.55 0.18 220 / 70%);
-  background: oklch(0.55 0.18 220 / 14%);
-}
-
 /* ── 访客分析面板 ──────────────────────────── */
 
 .analytics-card {
@@ -1572,8 +1633,8 @@
   gap: 4px;
   padding: 16px;
   border-radius: 8px;
-  border: 1px solid oklch(0.42 0 0 / 46%);
-  background: oklch(0.17 0 0 / 72%);
+  border: 1px solid var(--analytics-card-border);
+  background: var(--analytics-card-bg);
 }
 
 .analytics-card--kpi {
@@ -1591,7 +1652,7 @@
   font-size: 24px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: oklch(0.9 0 0);
+  color: var(--analytics-value);
 }
 
 .analytics-card__unit {
@@ -1604,13 +1665,13 @@
   margin-top: auto;
   font-size: 12px;
   line-height: 1.55;
-  color: oklch(0.64 0 0);
+  color: var(--analytics-explain);
 }
 
 .analytics-section {
-  border: 1px solid oklch(0.42 0 0 / 46%);
+  border: 1px solid var(--analytics-card-border);
   border-radius: 8px;
-  background: oklch(0.17 0 0 / 72%);
+  background: var(--analytics-card-bg);
   overflow: hidden;
 }
 
@@ -1621,8 +1682,8 @@
   padding: 12px 16px;
   font-size: 13px;
   font-weight: 600;
-  color: oklch(0.7 0 0);
-  border-bottom: 1px solid oklch(0.42 0 0 / 36%);
+  color: var(--analytics-section-title);
+  border-bottom: 1px solid var(--analytics-section-title-border);
 }
 
 .analytics-delta {
@@ -1652,8 +1713,8 @@
 
 .analytics-skeleton {
   border-radius: 8px;
-  border: 1px solid oklch(0.42 0 0 / 32%);
-  background: linear-gradient(90deg, oklch(0.2 0 0 / 60%), oklch(0.28 0 0 / 60%), oklch(0.2 0 0 / 60%));
+  border: 1px solid var(--analytics-skeleton-border);
+  background: var(--analytics-skeleton-bg);
   background-size: 200% 100%;
   animation: analytics-pulse 1.4s cubic-bezier(0.16, 1, 0.3, 1) infinite;
 }
@@ -1679,14 +1740,14 @@
 .analytics-empty__title {
   font-size: 13px;
   font-weight: 600;
-  color: oklch(0.78 0 0);
+  color: var(--analytics-empty-title);
 }
 
 .analytics-empty__detail {
   margin-top: 2px;
   font-size: 12px;
   line-height: 1.55;
-  color: oklch(0.55 0 0);
+  color: var(--analytics-empty-detail);
 }
 
 .analytics-error {
@@ -1717,8 +1778,8 @@
   gap: 12px;
   padding: 12px;
   border-radius: 8px;
-  border: 1px solid oklch(0.38 0 0 / 42%);
-  background: oklch(0.14 0 0 / 48%);
+  border: 1px solid var(--analytics-surface-border);
+  background: var(--analytics-surface-bg);
 }
 
 .analytics-insight__marker {
@@ -1746,7 +1807,7 @@
 .analytics-suggestion__title {
   font-size: 13px;
   font-weight: 650;
-  color: oklch(0.84 0 0);
+  color: var(--analytics-insight-title);
 }
 
 .analytics-insight__description,
@@ -1754,7 +1815,7 @@
   margin-top: 3px;
   font-size: 12px;
   line-height: 1.55;
-  color: oklch(0.63 0 0);
+  color: var(--analytics-insight-desc);
 }
 
 .analytics-insight__action,
@@ -1762,7 +1823,7 @@
   margin-top: 5px;
   font-size: 12px;
   line-height: 1.55;
-  color: oklch(0.76 0 0);
+  color: var(--analytics-insight-action);
 }
 
 .analytics-insight__metric,
@@ -1872,7 +1933,7 @@
   max-width: 32px;
   min-height: 2px;
   border-radius: 3px 3px 0 0;
-  background: linear-gradient(to top, oklch(0.5 0 0), oklch(0.74 0 0));
+  background: var(--analytics-bar-bg);
   transition: height 0.4s ease;
 }
 
@@ -1926,14 +1987,14 @@
 .analytics-list__meaning {
   font-size: 11px;
   line-height: 1.45;
-  color: oklch(0.52 0 0);
+  color: var(--analytics-list-meaning);
 }
 
 .analytics-list__name {
   flex-shrink: 0;
   width: 90px;
   font-size: 12px;
-  color: oklch(0.7 0 0);
+  color: var(--analytics-list-name);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1953,7 +2014,7 @@
   flex: 1;
   height: 6px;
   border-radius: 3px;
-  background: oklch(0.25 0 0 / 50%);
+  background: var(--analytics-bar-track-bg);
   overflow: hidden;
 }
 
@@ -1979,7 +2040,7 @@
   font-size: 12px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: oklch(0.65 0 0);
+  color: var(--analytics-list-count);
 }
 
 .settings-input {
@@ -2004,73 +2065,6 @@
   box-shadow: 0 0 0 2px color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
-/* 亮色模式 */
-[data-theme="light"] .analytics-card {
-  background: oklch(0.985 0 0);
-  border-color: oklch(0.72 0 0 / 58%);
-}
-
-[data-theme="light"] .analytics-card__value {
-  color: oklch(0.15 0 0);
-}
-
-[data-theme="light"] .analytics-section {
-  background: oklch(0.985 0 0);
-  border-color: oklch(0.72 0 0 / 58%);
-}
-
-[data-theme="light"] .analytics-section__title {
-  color: oklch(0.35 0 0);
-  border-bottom-color: oklch(0.78 0 0 / 46%);
-}
-
-[data-theme="light"] .analytics-chart__bar {
-  background: linear-gradient(to top, oklch(0.42 0 0), oklch(0.68 0 0));
-}
-
-[data-theme="light"] .analytics-list__bar-track {
-  background: oklch(0.92 0 0);
-}
-
-[data-theme="light"] .analytics-list__name {
-  color: oklch(0.35 0 0);
-}
-
-[data-theme="light"] .analytics-list__count {
-  color: oklch(0.35 0 0);
-}
-
-[data-theme="light"] .analytics-card__explain,
-[data-theme="light"] .analytics-insight__description,
-[data-theme="light"] .analytics-suggestion__reason,
-[data-theme="light"] .analytics-list__meaning,
-[data-theme="light"] .analytics-empty__detail {
-  color: oklch(0.42 0 0);
-}
-
-[data-theme="light"] .analytics-insight,
-[data-theme="light"] .analytics-suggestion {
-  background: oklch(0.96 0 0);
-  border-color: oklch(0.74 0 0 / 50%);
-}
-
-[data-theme="light"] .analytics-insight__title,
-[data-theme="light"] .analytics-suggestion__title,
-[data-theme="light"] .analytics-empty__title {
-  color: oklch(0.22 0 0);
-}
-
-[data-theme="light"] .analytics-insight__action,
-[data-theme="light"] .analytics-suggestion__action {
-  color: oklch(0.3 0 0);
-}
-
-[data-theme="light"] .analytics-skeleton {
-  border-color: oklch(0.74 0 0 / 45%);
-  background: linear-gradient(90deg, oklch(0.94 0 0), oklch(0.88 0 0), oklch(0.94 0 0));
-  background-size: 200% 100%;
-}
-
 .analytics-concentration,
 .analytics-quality-grid {
   display: grid;
@@ -2088,8 +2082,8 @@
 .analytics-filter {
   min-height: 76px;
   border-radius: 8px;
-  border: 1px solid oklch(0.38 0 0 / 42%);
-  background: oklch(0.14 0 0 / 48%);
+  border: 1px solid var(--analytics-surface-border);
+  background: var(--analytics-surface-bg);
   padding: 10px;
   text-align: left;
   transition: border-color 0.18s cubic-bezier(0.16, 1, 0.3, 1), background 0.18s cubic-bezier(0.16, 1, 0.3, 1);
@@ -2097,8 +2091,8 @@
 
 .analytics-filter:hover,
 .analytics-filter--active {
-  border-color: oklch(0.78 0 0 / 62%);
-  background: oklch(0.24 0 0 / 62%);
+  border-color: var(--analytics-filter-hover-border);
+  background: var(--analytics-filter-hover-bg);
 }
 
 .analytics-filter__label,
@@ -2107,7 +2101,7 @@
   display: block;
   font-size: 12px;
   font-weight: 650;
-  color: oklch(0.82 0 0);
+  color: var(--analytics-strong-text);
 }
 
 .analytics-filter__value {
@@ -2116,7 +2110,7 @@
   font-size: 22px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: oklch(0.9 0 0);
+  color: var(--analytics-big-value);
 }
 
 .analytics-filter__detail {
@@ -2124,7 +2118,7 @@
   margin-top: 4px;
   font-size: 11px;
   line-height: 1.45;
-  color: oklch(0.58 0 0);
+  color: var(--analytics-filter-detail);
 }
 
 .analytics-lifecycle,
@@ -2149,8 +2143,8 @@
 .analytics-search-grid > div {
   min-width: 0;
   border-radius: 8px;
-  border: 1px solid oklch(0.38 0 0 / 42%);
-  background: oklch(0.14 0 0 / 48%);
+  border: 1px solid var(--analytics-surface-border);
+  background: var(--analytics-surface-bg);
   padding: 12px;
 }
 
@@ -2166,7 +2160,7 @@
   white-space: nowrap;
   font-size: 12px;
   font-weight: 620;
-  color: oklch(0.82 0 0);
+  color: var(--analytics-strong-text);
 }
 
 .analytics-lifecycle__meta,
@@ -2177,7 +2171,7 @@
   gap: 8px;
   margin-top: 5px;
   font-size: 11px;
-  color: oklch(0.56 0 0);
+  color: var(--analytics-lifecycle-meta);
 }
 
 .analytics-lifecycle__item p,
@@ -2185,17 +2179,17 @@
   margin: 8px 0 0;
   font-size: 12px;
   line-height: 1.55;
-  color: oklch(0.66 0 0);
+  color: var(--analytics-lifecycle-desc);
 }
 
 .analytics-lifecycle__empty {
   margin-top: 10px;
   border-radius: 6px;
-  background: oklch(0.2 0 0 / 42%);
+  background: var(--analytics-empty-bg);
   padding: 10px;
   font-size: 12px;
   line-height: 1.5;
-  color: oklch(0.52 0 0);
+  color: var(--analytics-empty-text);
 }
 
 .analytics-search-row {
@@ -2208,7 +2202,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: oklch(0.78 0 0);
+  color: var(--analytics-search-name);
 }
 
 .analytics-report__actions {
@@ -2219,24 +2213,24 @@
 
 .analytics-report__actions span {
   border-radius: 6px;
-  background: oklch(0.22 0 0 / 52%);
+  background: var(--analytics-action-bg);
   padding: 7px 8px;
   font-size: 12px;
   line-height: 1.5;
-  color: oklch(0.7 0 0);
+  color: var(--analytics-action-text);
 }
 
 .analytics-report textarea {
   min-height: 220px;
   resize: vertical;
   border-radius: 8px;
-  border: 1px solid oklch(0.38 0 0 / 42%);
-  background: oklch(0.12 0 0 / 78%);
+  border: 1px solid var(--analytics-textarea-border);
+  background: var(--analytics-textarea-bg);
   padding: 12px;
   font-family: "SF Mono", "Fira Code", monospace;
   font-size: 11px;
   line-height: 1.6;
-  color: oklch(0.76 0 0);
+  color: var(--analytics-textarea-text);
   outline: none;
 }
 
@@ -2254,7 +2248,7 @@
   font-size: 24px;
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: oklch(0.9 0 0);
+  color: var(--analytics-big-value);
 }
 
 .analytics-quality-grid small {
@@ -2268,7 +2262,7 @@
   margin-top: 4px;
   font-size: 12px;
   line-height: 1.5;
-  color: oklch(0.58 0 0);
+  color: var(--analytics-concentration-label);
 }
 
 .analytics-concentration__explain {
@@ -2281,64 +2275,7 @@
   border-top: 1px solid oklch(0.42 0 0 / 34%);
   font-size: 12px;
   line-height: 1.55;
-  color: oklch(0.68 0 0);
-}
-
-[data-theme="light"] .analytics-concentration__value,
-[data-theme="light"] .analytics-quality-grid strong {
-  color: oklch(0.16 0 0);
-}
-
-[data-theme="light"] .analytics-concentration__label,
-[data-theme="light"] .analytics-quality-grid p,
-[data-theme="light"] .analytics-concentration__explain {
-  color: oklch(0.38 0 0);
-}
-
-[data-theme="light"] .analytics-filter,
-[data-theme="light"] .analytics-lifecycle__column,
-[data-theme="light"] .analytics-report > div,
-[data-theme="light"] .analytics-search-grid > div {
-  background: oklch(0.96 0 0);
-  border-color: oklch(0.74 0 0 / 50%);
-}
-
-[data-theme="light"] .analytics-filter:hover,
-[data-theme="light"] .analytics-filter--active {
-  border-color: oklch(0.36 0 0 / 50%);
-  background: oklch(0.92 0 0);
-}
-
-[data-theme="light"] .analytics-filter__label,
-[data-theme="light"] .analytics-lifecycle__heading,
-[data-theme="light"] .analytics-report__title,
-[data-theme="light"] .analytics-lifecycle__title,
-[data-theme="light"] .analytics-search-row span:first-child {
-  color: oklch(0.22 0 0);
-}
-
-[data-theme="light"] .analytics-filter__value {
-  color: oklch(0.16 0 0);
-}
-
-[data-theme="light"] .analytics-filter__detail,
-[data-theme="light"] .analytics-lifecycle__meta,
-[data-theme="light"] .analytics-lifecycle__item p,
-[data-theme="light"] .analytics-report p,
-[data-theme="light"] .analytics-search-row {
-  color: oklch(0.42 0 0);
-}
-
-[data-theme="light"] .analytics-lifecycle__empty,
-[data-theme="light"] .analytics-report__actions span {
-  background: oklch(0.9 0 0);
-  color: oklch(0.36 0 0);
-}
-
-[data-theme="light"] .analytics-report textarea {
-  border-color: oklch(0.74 0 0 / 50%);
-  background: oklch(0.94 0 0);
-  color: oklch(0.26 0 0);
+  color: var(--analytics-concentration-explain);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
### 变更类型

- [x] ♻️ **Refactor** — 代码重构

---

### 变更描述

**解决的问题**：Monolith 前端的主题颜色散落在两个地方——组件样式中的硬编码 `oklch()` 值（暗色默认），以及 125 处散落的 `[data-theme="light"]` 覆盖规则（亮色修正）。新增一套主题需要同时维护两套颜色，成本高且易遗漏。

**做了什么**：

1. 将文章排版、代码块、代码高亮、TOC、系列导航、评论表情、访客分析面板的硬编码颜色提取为语义化 CSS 变量（`--prose-*`、`--code-*`、`--hljs-*`、`--toc-*`、`--series-*`、`--reaction-*`、`--analytics-*`）
2. 暗色/亮色各收敛为一个完整的主题变量块，删除全部散落覆盖
3. 保留未被主题影响的固定语义色（图表状态色、错误红、macOS 圆点等）与既有 `var()` 用法不变

**为什么这样做**：此后每新增一套主题 = 定义一套变量块，组件零改动；也为"多主题切换"功能铺平道路。

---

### 测试情况

- [x] 本地开发环境测试通过（构建 + tsc 通过）
- [x] 不影响现有功能：341 组 (规则 × 暗/亮模式) 机器校验，暗/亮两模式渲染值与原版**完全等价**（零视觉变化）
- [x] 已更新相关文档（如适用）：无

---

### 截图（如有 UI 变更）

纯重构零视觉变化，无截图可对比；如需要可提供暗/亮两模式全页面截图。

---

### 注意事项

- 本次为纯重构，未引入任何组件逻辑变化
- 建议重点 review：`globals.css` 中新增的变量块与删除的覆盖段是否一一对应
